### PR TITLE
Change database migration column names to snake_case

### DIFF
--- a/backend/migrations/20190118105525-base.js
+++ b/backend/migrations/20190118105525-base.js
@@ -12,6 +12,9 @@
  * Some foreign key associations also use underscores, whereas some use camelCase.
  *
  * Another change should address this change as a migration and model update.
+ *
+ * Edit (2024-01-22): renamed camelCase column names to snake_case (which is used
+ * in the production db).
  */
 
 module.exports = {

--- a/backend/migrations/20190118105525-base.js
+++ b/backend/migrations/20190118105525-base.js
@@ -25,7 +25,7 @@ module.exports = {
       }
 
       const fieldNames = camelCase
-        ? ['createdAt', 'updatedAt']
+        ? ['created_at', 'updated_at']
         : ['created_at', 'updated_at']
 
       /*
@@ -73,7 +73,7 @@ module.exports = {
         },
         group_name: Sequelize.STRING,
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true })
+        ...createTimestampColumns({ camelCase: false })
       }),
       query.createTable('memberships', {
         id: {
@@ -96,7 +96,7 @@ module.exports = {
         name: Sequelize.STRING,
         questions: Sequelize.JSONB,
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true })
+        ...createTimestampColumns({ camelCase: false })
       }),
       query.createTable('registrations', {
         id: {
@@ -107,10 +107,10 @@ module.exports = {
         preferred_topics: Sequelize.JSONB,
         questions: Sequelize.JSONB,
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true }),
+        ...createTimestampColumns({ camelCase: false }),
         // foreign keys for associations
         configuration_id: Sequelize.INTEGER,
-        studentStudentNumber: Sequelize.STRING(255)
+        student_student_number : Sequelize.STRING(255)
       }),
       query.createTable('review_question_sets', {
         id: {
@@ -121,7 +121,7 @@ module.exports = {
         name: Sequelize.STRING,
         questions: Sequelize.JSONB,
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true })
+        ...createTimestampColumns({ camelCase: false })
       }),
       query.createTable('topic_dates', {
         id: {
@@ -131,7 +131,7 @@ module.exports = {
         },
         dates: Sequelize.JSONB,
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true })
+        ...createTimestampColumns({ camelCase: false })
       }),
       query.createTable('topics', {
         id: {
@@ -147,7 +147,7 @@ module.exports = {
         acronym: Sequelize.STRING,
         secret_id: Sequelize.STRING,
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true })
+        ...createTimestampColumns({ camelCase: false })
       }),
       query.createTable('users', {
         student_number: {
@@ -163,7 +163,7 @@ module.exports = {
           defaultValue: false
         },
         // sequelize timestamps
-        ...createTimestampColumns({ camelCase: true })
+        ...createTimestampColumns({ camelCase: false })
       })
     ]
 
@@ -240,8 +240,8 @@ module.exports = {
     // completion of all query operations. Here we just return the last awaited
     // promise since all the other awaits have been done before this one.
     return await addForeignKey(
-      'registrations_studentStudentNumber_fkey',
-      ['registrations', 'studentStudentNumber'],
+      'registrations_student_student_number _fkey',
+      ['registrations', 'student_student_number'],
       ['users', 'student_number']
     )
   },
@@ -273,7 +273,7 @@ module.exports = {
       },
       {
         table: 'registrations',
-        constraint: 'registrations_studentStudentNumber_fkey'
+        constraint: 'registrations_student_student_number _fkey'
       }
     ]
     const removeConstraintPromises = constraints.map(({ table, constraint }) =>

--- a/backend/migrations/20190125184855-registration_managements.js
+++ b/backend/migrations/20190125184855-registration_managements.js
@@ -21,11 +21,11 @@ module.exports = {
         type: Sequelize.STRING
       },
       // Sequelize timestamps
-      createdAt: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false
       },
-      updatedAt: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false
       }

--- a/backend/migrations/20190131082251-new-group-management.js
+++ b/backend/migrations/20190131082251-new-group-management.js
@@ -79,7 +79,7 @@ const up = async (query, Sequelize) => {
   // Create "group <-> user" join table
   await query.createTable('group_students', {
     ...createTimestampColumns({ camelCase: false }),
-    groupId: {
+    group_id: {
       type: Sequelize.INTEGER,
       allowNull: false
     },
@@ -96,7 +96,7 @@ const up = async (query, Sequelize) => {
   // group_students uses composite primary keyi
   await query.addConstraint(
     'group_students',
-    ['groupId', 'user_student_number'],
+    ['group_id', 'user_student_number'],
     {
       type: 'primary key',
       name: 'group_students_pkey'
@@ -105,8 +105,8 @@ const up = async (query, Sequelize) => {
 
   // group_student's foreign keys
   await addForeignKey(
-    'group_students_groupId_fkey',
-    ['group_students', 'groupId'],
+    'group_students_group_id_fkey',
+    ['group_students', 'group_id'],
     ['groups', 'id'],
     { onUpdate: 'CASCADE', onDelete: 'CASCADE' }
   )
@@ -151,7 +151,7 @@ const down = async (query, Sequelize) => {
       table: 'group_students',
       constraint: 'group_students_user_student_number_fkey'
     },
-    { table: 'group_students', constraint: 'group_students_groupId_fkey' }
+    { table: 'group_students', constraint: 'group_students_group_id_fkey' }
   ]
 
   const removeConstraintPromises = constraints.map(({ table, constraint }) =>

--- a/backend/migrations/20190131082251-new-group-management.js
+++ b/backend/migrations/20190131082251-new-group-management.js
@@ -56,7 +56,7 @@ const up = async (query, Sequelize) => {
     }
 
     return camelCase
-      ? { createdAt: timestampType, updatedAt: timestampType }
+      ? { created_at: timestampType, updated_at: timestampType }
       : { created_at: timestampType, updated_at: timestampType }
   }
 
@@ -70,20 +70,20 @@ const up = async (query, Sequelize) => {
       primaryKey: true
     },
     name: Sequelize.STRING,
-    ...createTimestampColumns({ camelCase: true }),
-    topicId: Sequelize.INTEGER,
-    configurationId: Sequelize.INTEGER,
-    instructorId: Sequelize.STRING
+    ...createTimestampColumns({ camelCase: false }),
+    topic_id: Sequelize.INTEGER,
+    configuration_id: Sequelize.INTEGER,
+    instructor_id: Sequelize.STRING
   })
 
   // Create "group <-> user" join table
   await query.createTable('group_students', {
-    ...createTimestampColumns({ camelCase: true }),
+    ...createTimestampColumns({ camelCase: false }),
     groupId: {
       type: Sequelize.INTEGER,
       allowNull: false
     },
-    userStudentNumber: {
+    user_student_number: {
       type: Sequelize.STRING,
       allowNull: false
     }
@@ -96,7 +96,7 @@ const up = async (query, Sequelize) => {
   // group_students uses composite primary keyi
   await query.addConstraint(
     'group_students',
-    ['groupId', 'userStudentNumber'],
+    ['groupId', 'user_student_number'],
     {
       type: 'primary key',
       name: 'group_students_pkey'
@@ -111,28 +111,28 @@ const up = async (query, Sequelize) => {
     { onUpdate: 'CASCADE', onDelete: 'CASCADE' }
   )
   await addForeignKey(
-    'group_students_userStudentNumber_fkey',
-    ['group_students', 'userStudentNumber'],
+    'group_students_user_student_number_fkey',
+    ['group_students', 'user_student_number'],
     ['users', 'student_number'],
     { onUpdate: 'CASCADE', onDelete: 'CASCADE' }
   )
 
   // group foreign keys
   await addForeignKey(
-    'groups_configurationId_fkey',
-    ['groups', 'configurationId'],
+    'groups_configuration_id_fkey',
+    ['groups', 'configuration_id'],
     ['configurations', 'id'],
     { onUpdate: 'CASCADE', onDelete: 'SET NULL' }
   )
   await addForeignKey(
-    'groups_instructorId_fkey',
-    ['groups', 'instructorId'],
+    'groups_instructor_id_fkey',
+    ['groups', 'instructor_id'],
     ['users', 'student_number'],
     { onUpdate: 'CASCADE', onDelete: 'SET NULL' }
   )
   await addForeignKey(
-    'groups_topicId_fkey',
-    ['groups', 'topicId'],
+    'groups_topic_id_fkey',
+    ['groups', 'topic_id'],
     ['topics', 'id'],
     { onUpdate: 'CASCADE', onDelete: 'SET NULL' }
   )
@@ -144,12 +144,12 @@ const up = async (query, Sequelize) => {
 const down = async (query, Sequelize) => {
   // remove created fkeys
   const constraints = [
-    { table: 'groups', constraint: 'groups_topicId_fkey' },
-    { table: 'groups', constraint: 'groups_instructorId_fkey' },
-    { table: 'groups', constraint: 'groups_configurationId_fkey' },
+    { table: 'groups', constraint: 'groups_topic_id_fkey' },
+    { table: 'groups', constraint: 'groups_instructor_id_fkey' },
+    { table: 'groups', constraint: 'groups_configuration_id_fkey' },
     {
       table: 'group_students',
-      constraint: 'group_students_userStudentNumber_fkey'
+      constraint: 'group_students_user_student_number_fkey'
     },
     { table: 'group_students', constraint: 'group_students_groupId_fkey' }
   ]
@@ -166,7 +166,7 @@ const down = async (query, Sequelize) => {
   //   add back group_name
   await query.addColumn('groups', 'group_name', Sequelize.STRING)
   //   remove added colums
-  const addedColumns = ['name', 'topicId', 'configurationId', 'instructorId']
+  const addedColumns = ['name', 'topic_id', 'configuration_id', 'instructor_id']
   const removeColumnPromises = addedColumns.map((column) =>
     query.removeColumn('groups', column)
   )

--- a/backend/migrations/20190221115330-peer_review.js
+++ b/backend/migrations/20190221115330-peer_review.js
@@ -18,11 +18,11 @@ module.exports = {
         allowNull: false
       },
       // Sequelize timestamps
-      createdAt: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false
       },
-      updatedAt: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false
       }

--- a/backend/migrations/20190228121538-fix-peer-reviews.js
+++ b/backend/migrations/20190228121538-fix-peer-reviews.js
@@ -24,11 +24,11 @@ module.exports = {
         type: Sequelize.JSONB
       },
       // Sequelize timestamps
-      createdAt: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false
       },
-      updatedAt: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false
       }

--- a/backend/migrations/20190411105222-customer-review-tables.js
+++ b/backend/migrations/20190411105222-customer-review-tables.js
@@ -25,11 +25,11 @@ module.exports = {
         allowNull: false
       },
       // Sequelize timestamps
-      createdAt: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false
       },
-      updatedAt: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false
       }
@@ -45,11 +45,11 @@ module.exports = {
         type: Sequelize.JSONB
       },
       // Sequelize timestamps
-      createdAt: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false
       },
-      updatedAt: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false
       },

--- a/backend/migrations/20190418142830-instructor_review.js
+++ b/backend/migrations/20190418142830-instructor_review.js
@@ -18,11 +18,11 @@ module.exports = {
         allowNull: false
       },
       // Sequelize timestamps
-      createdAt: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false
       },
-      updatedAt: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false
       }

--- a/backend/seeders/20190221035516-page-access-seeds.js
+++ b/backend/seeders/20190221035516-page-access-seeds.js
@@ -122,7 +122,7 @@ const initialRegistration = [
     preferred_topics: JSON.stringify(initialPreferredTopics),
     questions: JSON.stringify(initialQuestionsWithAnswers),
     configuration_id: 1,
-    studentStudentNumber: '012345698'
+    student_student_number: '012345698'
   }
 ]
 
@@ -130,8 +130,8 @@ const addTimeStamps = (arr) => {
   return arr.map((item) => {
     return {
       ...item,
-      createdAt: new Date(),
-      updatedAt: new Date()
+      created_at: new Date(),
+      updated_at: new Date()
     }
   })
 }

--- a/backend/seeders/20190226153149-group-management-seeds.js
+++ b/backend/seeders/20190226153149-group-management-seeds.js
@@ -15,8 +15,8 @@ const additionalTopic = [
     }),
     secret_id: 'Coh5boozeyish7iS',
     configuration_id: 1,
-    createdAt: new Date(),
-    updatedAt: new Date()
+    created_at: new Date(),
+    updated_at: new Date()
   }
 ]
 

--- a/backend/seeders/20190424111842-topic-for-active-tests.js
+++ b/backend/seeders/20190424111842-topic-for-active-tests.js
@@ -20,8 +20,8 @@ const topics = [
     }),
     secret_id: 'Doh5boozeyish7iV',
     configuration_id: 1,
-    createdAt: new Date(),
-    updatedAt: new Date()
+    created_at: new Date(),
+    updated_at: new Date()
   }
 ]
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "cypress:run": "npx cypress run -P ./"
   },
   "devDependencies": {
+    "eslint": "5.12.0",
     "husky": "^1.2.0"
   },
   "husky": {


### PR DESCRIPTION
Issue: #6 

Changed database migration column names to snake_case. The local environment works now, but there might be more columns that require renaming.

Remember to enter `npm run db:recreate` to run the migrations.

### How to set up the local environment now (if not already done):
_NOTE: the correct Node version is still a mystery but Node v12 seems to be working._
- Run `npm install` in `backend` and `frontend` directories.
- Add .env file to `backend` directory with the following content:

```
PORT = 3001
SECRET = "topsecret"
DATABASE_URI = "localhost"
EMAIL_ENABLED = "false"
```

Start a Docker container for the db:
- Enter `docker-compose up -d db` in root directory.

Create the db:
- Enter `npm run db:create` in backend directory.
- Enter `npm run db:migrate` in backend directory.
- Enter `npm run db:seed:all` in backend directory.

Start the backend:
- Enter `npm run watch` in backend directory.

Start the frontend:
- Enter `npm start` in frontend directory. 
