### PR TITLE
Use mock headers for dev environment

### DIFF
--- a/backend/controllers/login.js
+++ b/backend/controllers/login.js
@@ -2,7 +2,6 @@ const loginRouter = require('express').Router()
 const jwt = require('jsonwebtoken')
 const config = require('../config/')
 const db = require('../models/index')
-const { isDevelopmentEnvironment } = require('../utils/index')
 
 const handleDatabaseError = (res, error) => {
   console.log(error)
@@ -12,16 +11,13 @@ const handleDatabaseError = (res, error) => {
 }
 
 loginRouter.post('/', async (req, res) => {
-  if (!req.headers.hypersonstudentid && !isDevelopmentEnvironment())
+  if (!req.headers.hypersonstudentid)
     return res
       .status(401)
       .json({ error: 'Student number missing from headers.' })
       .end()
 
-  // TODO: this is a quick fix. Let's discuss later how to deal with the headers in local environment
-  const student_number = isDevelopmentEnvironment()
-    ? '012345688'
-    : req.headers.hypersonstudentid
+  const student_number = req.headers.hypersonstudentid
 
   db.User.findOne({
     where: { student_number },

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,7 +2,8 @@ const http = require('http')
 const express = require('express')
 const bodyParser = require('body-parser')
 const cors = require('cors')
-const { logger } = require('./middleware')
+const { logger, fakeshibbo } = require('./middleware')
+const { isDevelopmentEnvironment } = require('./utils/index')
 const headersMiddleware = require('unfuck-utf8-headers-middleware')
 const config = require('./config/')
 const app = express()
@@ -25,13 +26,15 @@ const shibbolethHeaders = [
   'givenname', // First name
   'mail', // Email
   'hypersonstudentid', // Contains student number
-  'sn' // Last name
+  'sn', // Last name
 ]
 
 // Middleware
 app.use(cors())
 app.use(bodyParser.json())
-app.use(headersMiddleware(shibbolethHeaders))
+!isDevelopmentEnvironment()
+  ? app.use(headersMiddleware(shibbolethHeaders))
+  : app.use(fakeshibbo)
 app.use(unless('/api/login', logger))
 
 // Routers
@@ -93,5 +96,5 @@ server.on('close', () => {
 
 module.exports = {
   app,
-  server
+  server,
 }

--- a/backend/middleware.js
+++ b/backend/middleware.js
@@ -86,11 +86,11 @@ const checkAdmin = (req, res, next) => {
 /** @type {RequestHandler} */
 const fakeshibbo = (req, res, next) => {
   req.headers.employeenumber = '9876543'
-  req.headers.mail = 'pekka.m.testaaja@helsinki.fi'
-  req.headers.hypersonstudentid = '011110002'
-  req.headers.uid = 'pemtest'
-  req.headers.givenname = 'Pekka'
-  req.headers.sn = 'Testaaja'
+  req.headers.mail = ''
+  req.headers.hypersonstudentid = '012345688'
+  req.headers.uid = 'testertester2'
+  req.headers.givenname = 'Angela'
+  req.headers.sn = 'Merkel'
   next()
 }
 


### PR DESCRIPTION
resolves: #33

- Use mock headers for dev environment.
- Changed the mock header user to Angela Merkel as she's an admin.
- Removed the isDevelopmentEnvironment() check from `/login` api as it's not needed anymore.