### PR TITLE
Fix Cypress tests

### DIFF
--- a/frontend/e2e/run_cypress_e2e.sh
+++ b/frontend/e2e/run_cypress_e2e.sh
@@ -74,15 +74,15 @@ function run() {
     if [ "${CI}" == 'true' ]; then
         # Record runs to the Cypress Dashboard if we're in CI
         # Assume CYPRESS_RECORD_KEY has been set in travis
-        CYPRESS_baseUrl=http://localhost:3000/projekti npm run cypress:run -- --record
+        CYPRESS_baseUrl=http://localhost:3000/ npm run cypress:run -- --record
     else
         # probably running locally
-        CYPRESS_baseUrl=http://localhost:3000/projekti npm run cypress:run
+        CYPRESS_baseUrl=http://localhost:3000/ npm run cypress:run
     fi
 }
 
 function open() {
-    CYPRESS_baseUrl=http://localhost:3000/projekti npm run cypress:open
+    CYPRESS_baseUrl=http://localhost:3000/ npm run cypress:open
 }
 
 if [ "$1" == 'run' ]; then


### PR DESCRIPTION
- Branch for fixing the Cypress tests.

**How to run tests**
Enter the following commands in the `frontend` directory:
- `npm run e2e:install`
- `npm run e2e:setup`
- `npm run e2e:run or npm run e2e:open`

Do this after you are done with the tests, otherwise `e2e:setup` won't work the next time (due to duplicate data in the db):
- `npm run e2e:teardown`
