### PR TITLE
Fix: wrong content rendered as default in Topics page

### DIFF
--- a/frontend/src/components/TopicListPage.js
+++ b/frontend/src/components/TopicListPage.js
@@ -410,7 +410,7 @@ const TopicListPage = (props) => {
   useEffect(() => {
     const updateData = async () => {
       if (configurations.length)
-        await updateFilter([...configurations].reverse()[0].id)
+        await updateFilter(configurations[0].id)
     }
 
     updateData()


### PR DESCRIPTION
Due to PR #74 `reverse()` is not needed anymore for rendering the latest content as default.