### PR TITLE
skip originally failing tests

### DIFF
--- a/frontend/e2e/cypress/integration/answerPeerReview.spec.js
+++ b/frontend/e2e/cypress/integration/answerPeerReview.spec.js
@@ -41,20 +41,20 @@ describe('Answering peer review', () => {
     )
   })
 
-  it('peer review is open', () => {
+  it.skip('peer review is open', () => {
     cy.loginAsRegisteredUser()
     cy.visit('/peerreview')
     cy.get('.peer-review-container').contains('This is info')
   })
 
-  it('shows an error if none of the fields is filled', () => {
+  it.skip('shows an error if none of the fields is filled', () => {
     cy.loginAsRegisteredUser()
     cy.visit('/peerreview')
     cy.contains('Submit').click()
     cy.contains('You must answer all questions')
   })
 
-  it('shows an error if only one of the fields is filled', () => {
+  it.skip('shows an error if only one of the fields is filled', () => {
     cy.loginAsRegisteredUser()
     cy.visit('/peerreview')
     cy.get(
@@ -66,7 +66,7 @@ describe('Answering peer review', () => {
     cy.contains('You must answer all questions')
   })
 
-  it('shows an error if not all of the radio button questions is answered', () => {
+  it.skip('shows an error if not all of the radio button questions is answered', () => {
     cy.loginAsRegisteredUser()
     cy.visit('/peerreview')
     cy.get(
@@ -84,7 +84,7 @@ describe('Answering peer review', () => {
     cy.contains('You must answer all questions')
   })
 
-  it('shows a submit confimation when all field and butotns are filled properly', () => {
+  it.skip('shows a submit confimation when all field and butotns are filled properly', () => {
     cy.loginAsRegisteredUser()
     cy.visit('/peerreview')
     cy.get(

--- a/frontend/e2e/cypress/integration/instructorReview.spec.js
+++ b/frontend/e2e/cypress/integration/instructorReview.spec.js
@@ -28,7 +28,7 @@ const expectNotification = (text) => {
   cy.get('.notification').should('be.text', text)
 }
 
-describe.skip('Instructor review page', () => {
+describe('Instructor review page', () => {
   before(() => {
     initTests()
   })
@@ -46,13 +46,13 @@ describe.skip('Instructor review page', () => {
     expectNotification('You must answer all questions')
   })
 
-  it('shows error when text fields are under 5 characters long', () => {
+  it.skip('shows error when text fields are under 5 characters long', () => {
     answerTextInput('foo', 0)
     submitInstructorReview()
     expectNotification('Text answers must be over 5 characters long.')
   })
 
-  it('shows error when text fields are filled but there are other unfilled fields', () => {
+  it.skip('shows error when text fields are filled but there are other unfilled fields', () => {
     answerTextInput(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at.',
       0
@@ -61,7 +61,7 @@ describe.skip('Instructor review page', () => {
     expectNotification('You must answer all questions')
   })
 
-  it('shows error when number fields are filled but are higher than 5', () => {
+  it.skip('shows error when number fields are filled but are higher than 5', () => {
     answerTextInput(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at.',
       0
@@ -71,7 +71,7 @@ describe.skip('Instructor review page', () => {
     expectNotification('Grade can not be over 5.')
   })
 
-  it('shows error when number fields are filled but are lower than 5', () => {
+  it.skip('shows error when number fields are filled but are lower than 5', () => {
     answerTextInput(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at.',
       0
@@ -81,7 +81,7 @@ describe.skip('Instructor review page', () => {
     expectNotification('Number answer can not be negative')
   })
 
-  it('submits instructor review when all fields are filled', () => {
+  it.skip('submits instructor review when all fields are filled', () => {
     answerTextInput(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at.',
       0

--- a/frontend/e2e/cypress/integration/pageAccess.spec.js
+++ b/frontend/e2e/cypress/integration/pageAccess.spec.js
@@ -19,116 +19,116 @@ const assertIsAlreadyRegistered = () => {
   cy.contains('You have already registered to current project')
 }
 
-describe.skip('Page access and redirect tests', () => {
+describe('Page access and redirect tests', () => {
   describe('Page access without authentication', () => {
-    it('/administration/configuration redirects user to login page', () => {
+    it.skip('/administration/configuration redirects user to login page', () => {
       cy.visit('/administration/configuration')
       assertIsOnLoginPage()
     })
 
-    it('/administration/customer-review-questions redirects user to login page', () => {
+    it.skip('/administration/customer-review-questions redirects user to login page', () => {
       cy.visit('/administration/customer-review-questions')
       assertIsOnLoginPage()
     })
 
-    it('/administration/groups redirects user to login page', () => {
+    it.skip('/administration/groups redirects user to login page', () => {
       cy.visit('/administration/groups')
       assertIsOnLoginPage()
     })
 
-    it('/administration/participants redirects user to login page', () => {
+    it.skip('/administration/participants redirects user to login page', () => {
       cy.visit('/administration/participants')
       assertIsOnLoginPage()
     })
 
-    it('/administration/peer-review-questions redirects user to login page', () => {
+    it.skip('/administration/peer-review-questions redirects user to login page', () => {
       cy.visit('/administration/peer-review-questions')
       assertIsOnLoginPage()
     })
 
-    it('/administration/registration-questions redirects user to login page', () => {
+    it.skip('/administration/registration-questions redirects user to login page', () => {
       cy.visit('/administration/registration-questions')
       assertIsOnLoginPage()
     })
 
-    it('/administration/registrationmanagement redirects user to login page', () => {
+    it.skip('/administration/registrationmanagement redirects user to login page', () => {
       cy.visit('/administration/registrationmanagement')
       assertIsOnLoginPage()
     })
 
-    it('/administration/email-templates redirects user to login page', () => {
+    it.skip('/administration/email-templates redirects user to login page', () => {
       cy.visit('/administration/email-templates')
       assertIsOnLoginPage()
     })
 
-    it('/peerreview redirects user to login page', () => {
+    it.skip('/peerreview redirects user to login page', () => {
       cy.visit('/peerreview')
       assertIsOnLoginPage()
     })
 
-    it('/registrationdetails redirects user to login page', () => {
+    it.skip('/registrationdetails redirects user to login page', () => {
       cy.visit('/registrationdetails')
       assertIsOnLoginPage()
     })
 
-    it('/register redirects user to login page', () => {
+    it.skip('/register redirects user to login page', () => {
       cy.visit('/register')
       assertIsOnLoginPage()
     })
 
-    it('/topics redirects user to login page', () => {
+    it.skip('/topics redirects user to login page', () => {
       cy.visit('/topics')
       assertIsOnLoginPage()
     })
   })
 
-  describe.skip('Page access for user', () => {
+  describe('Page access for user', () => {
     beforeEach(() => {
       cy.loginAsUnregisteredUser()
       cy.visit('/')
     })
 
-    it('/administration/configuration redirects user to landing page', () => {
+    it.skip('/administration/configuration redirects user to landing page', () => {
       cy.visit('/administration/configuration')
       assertIsOnLandingPage()
     })
 
-    it('/administration/customer-review-questions redirects user to landing page', () => {
+    it.skip('/administration/customer-review-questions redirects user to landing page', () => {
       cy.visit('/administration/customer-review-questions')
       assertIsOnLandingPage()
     })
 
-    it('/administration/groups redirects user to landing page', () => {
+    it.skip('/administration/groups redirects user to landing page', () => {
       cy.visit('/administration/groups')
       assertIsOnLandingPage()
     })
 
-    it('/administration/participants redirects user to landing page', () => {
+    it.skip('/administration/participants redirects user to landing page', () => {
       cy.visit('/administration/participants')
       assertIsOnLandingPage()
     })
 
-    it('/administration/peer-review-questions redirects user to landing page', () => {
+    it.skip('/administration/peer-review-questions redirects user to landing page', () => {
       cy.visit('/administration/peer-review-questions')
       assertIsOnLandingPage()
     })
 
-    it('/administration/registration-questions redirects user to landing page', () => {
+    it.skip('/administration/registration-questions redirects user to landing page', () => {
       cy.visit('/administration/registration-questions')
       assertIsOnLandingPage()
     })
 
-    it('/administration/registrationmanagement redirects user to landing page', () => {
+    it.skip('/administration/registrationmanagement redirects user to landing page', () => {
       cy.visit('/administration/registrationmanagement')
       assertIsOnLandingPage()
     })
 
-    it('/administration/email-templates redirects user to login page', () => {
+    it.skip('/administration/email-templates redirects user to login page', () => {
       cy.visit('/administration/email-templates')
       assertIsOnLandingPage()
     })
 
-    it('/topics redirects user to landing page', () => {
+    it.skip('/topics redirects user to landing page', () => {
       cy.visit('/topics')
       assertIsOnLandingPage()
     })
@@ -146,13 +146,13 @@ describe.skip('Page access and redirect tests', () => {
     })
   })
 
-  describe.skip('Page access for registered user', () => {
+  describe('Page access for registered user', () => {
     beforeEach(() => {
       cy.loginAsRegisteredUser()
       cy.visit('/')
     })
 
-    it('/login redirects to /registrationdetails', () => {
+    it.skip('/login redirects to /registrationdetails', () => {
       cy.visit('/login')
       assertIsOnRegistrationDetailsPage()
     })
@@ -163,7 +163,7 @@ describe.skip('Page access and redirect tests', () => {
     })
   })
 
-  describe.skip('Page access for admin', () => {
+  describe('Page access for admin', () => {
     beforeEach(() => {
       cy.loginAsAdmin()
       cy.visit('/')
@@ -229,13 +229,13 @@ describe.skip('Page access and redirect tests', () => {
     })
   })
 
-  describe.skip('404 handler', () => {
+  describe('404 handler', () => {
     it('shows a 404 not found page when entering an url that is not found', () => {
       cy.visit('/amksfmkafg-qfq435tefds')
       cy.get('.not-found-page').contains('Page not found')
     })
 
-    it('redirects to / when clicking the return link', () => {
+    it.skip('redirects to / when clicking the return link', () => {
       cy.visit('/amksfmkafg-qfq435tefds')
       cy.get('.not-found-page')
         .find('[data-cy="return-link"]')

--- a/frontend/e2e/cypress/integration/registrationQuestionsPage.spec.js
+++ b/frontend/e2e/cypress/integration/registrationQuestionsPage.spec.js
@@ -96,7 +96,7 @@ describe('Registration-questions page', () => {
         .should('have.length', 1)
     })
 
-    it('creates questions of type scale, text and <empty>', () => {
+    it.skip('creates questions of type scale, text and <empty>', () => {
       createQuestionSet('k2000', [
         {
           question: 'This is a title'

--- a/frontend/e2e/cypress/integration/reviewQuestionsPage.spec.js
+++ b/frontend/e2e/cypress/integration/reviewQuestionsPage.spec.js
@@ -171,7 +171,7 @@ describe('Review-questions page', () => {
       cy.visit('/administration/peer-review-questions')
     })
 
-    it('does not save changes if both name and questions are empty', () => {
+    it.skip('does not save changes if both name and questions are empty', () => {
       createQuestionSet('With options tester', [
         {
           header: 'Do we have a right header here?',
@@ -196,7 +196,7 @@ describe('Review-questions page', () => {
       cy.get('.question-set-item-editor')
     })
 
-    it('shows error if new JSON is invalid', () => {
+    it.skip('shows error if new JSON is invalid', () => {
       createQuestionSet('No options tester', [
         {
           header: 'Do we have a right header here?',
@@ -254,7 +254,7 @@ describe('Review-questions page', () => {
       cy.get('.question-set-item__content').contains('Little')
     })
 
-    it('edits questions without changing name', () => {
+    it.skip('edits questions without changing name', () => {
       createQuestionSet('Number question tester', [
         {
           header: 'Do we have a right header here?',


### PR DESCRIPTION
- all originally failing tests (as of 24th Jan before our code changes) marked as skip
- tests are skipped one-by-one, no block skips (skip not in describe, but in "it")
- failing tests with this setup should mean that we have broken tests / code after 24th Jan