### PR TITLE
Fix `renders-peerreview-when-visited` test

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -32,9 +32,8 @@ const shibbolethHeaders = [
 // Middleware
 app.use(cors())
 app.use(bodyParser.json())
-!isDevelopmentEnvironment()
-  ? app.use(headersMiddleware(shibbolethHeaders))
-  : app.use(fakeshibbo)
+app.use(headersMiddleware(shibbolethHeaders))
+isDevelopmentEnvironment() && app.use(fakeshibbo)
 app.use(unless('/api/login', logger))
 
 // Routers

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,44 +1,30 @@
 module.exports = {
-    "env": {
-        "es6": true,
-        "node": true,
-        "browser": true
+  env: {
+    es6: true,
+    node: true,
+    browser: true,
+  },
+  extends: 'eslint:recommended',
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
     },
-    "extends": "eslint:recommended",
-    "parser": "babel-eslint",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 2018,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react"
-    ],
-    "rules": {
-        "react/jsx-uses-react": "error",
-        "react/jsx-uses-vars": "error" ,
-        "indent": [
-            "error",
-            2
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ],
-        "eqeqeq": "error",
-        "no-trailing-spaces": "error",
-        "object-curly-spacing": [
-            "error", "always"
-        ],
-        "arrow-spacing": [
-            "error", { "before": true, "after": true }
-        ],
-        "no-console" : 0
-    }
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+  plugins: ['react'],
+  rules: {
+    'react/jsx-uses-react': 'error',
+    'react/jsx-uses-vars': 'error',
+    indent: ['error', 2],
+    quotes: ['error', 'single'],
+    semi: ['error', 'never'],
+    eqeqeq: 'error',
+    'no-trailing-spaces': 'error',
+    'object-curly-spacing': ['error', 'always'],
+    'arrow-spacing': ['error', { before: true, after: true }],
+    'no-console': 0,
+  },
+  ignorePatterns: ['e2e/'],
 }

--- a/frontend/e2e/cypress/integration/pageAccess.spec.js
+++ b/frontend/e2e/cypress/integration/pageAccess.spec.js
@@ -136,7 +136,7 @@ describe('Page access and redirect tests', () => {
     it('renders /peerreview when visited', () => {
       cy.visit('/peerreview')
       cy.url().should('include', '/peerreview')
-      cy.contains('You are not currently assigned to any group!')
+      cy.contains('You are currently not assigned to any group.')
     })
 
     it('renders /register when visited', () => {
@@ -237,9 +237,7 @@ describe('Page access and redirect tests', () => {
 
     it.skip('redirects to / when clicking the return link', () => {
       cy.visit('/amksfmkafg-qfq435tefds')
-      cy.get('.not-found-page')
-        .find('[data-cy="return-link"]')
-        .click()
+      cy.get('.not-found-page').find('[data-cy="return-link"]').click()
 
       assertIsOnLoginPage()
     })

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -80,7 +80,11 @@ const App = (props) => {
   useEffect(() => {
     const handleLogin = async () => {
       if (!window.location.href.includes('customer-review/')) {
-        await loginUser()
+        try {
+          await loginUser()
+        } catch (err) {
+          console.log(err)
+        }
       }
     }
 
@@ -93,10 +97,13 @@ const App = (props) => {
     }
 
     fetchData()
-
     const loginInterval = setInterval(() => {
       if (!window.location.href.includes('customer-review/')) {
-        loginService.login()
+        try {
+          loginService.login()
+        } catch (err) {
+          console.log(err)
+        }
       }
     }, 60 * 1000)
 


### PR DESCRIPTION
- Add `e2e` directory to eslint ignorePatterns as eslint keeps nagging about Cypress functions.
- Add try-catch blocks to App.js. The login requests fail in test environment (as expected) and the errors were not caught, which caused some of the App.js fetch functions not to run and the `renders-peerreview-when-visited` test to fail.