### PR TITLE
Add .nvmrc files under backend and frontend

### DIFF
--- a/backend/.nvmrc
+++ b/backend/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium

--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,0 +1,1 @@
+lts/dubnium


### PR DESCRIPTION
From the README for [Node Version Manager](https://github.com/nvm-sh/nvm):

>You can create a `.nvmrc` file containing a node version number (or any other string that `nvm` understands; see `nvm --help` for details) in the project root directory (or any parent directory). Afterwards, `nvm use`, `nvm install`, `nvm exec`, `nvm run`, and `nvm which` will use the version specified in the `.nvmrc` file if no version is supplied on the command line.

If you'd like to, e.g., automatically use the version defined in .nvmrc when _cd_'ing, have a look at [_Deeper Shell Integration_](https://github.com/nvm-sh/nvm/#deeper-shell-integration).

The codenames of LTS versions defined in this PR correspond to

```console
$ nvm list
...
lts/dubnium -> v10.24.1
lts/erbium -> v12.22.12
...
```