### PR TITLE
Fix GitHub Actions issue with Cypress Record Key

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
+    secrets: inherit
 
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fix the issue with Cypress tests in main branch. Repository secrets have to be passed explicitly to test action, otherwise test action can't read them.