### PR TITLE
Fix/time logs front validation

### DIFF
--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -98,23 +98,6 @@ describe('Time logs & sprints', () => {
     cy.get('#timelog-rows').children().should('have.length', 2)
   })
 
-  // this test will fail when frontend validation is done properly, remove at that point
-  it('shows error from backend when creating timeLog fails too short description', () => {
-    cy.visit('/timelogs')
-    cy.get('.timelogs-container-1').should('exist')
-    cy.get('.input-container').should('exist')
-    cy.get('.date').type('2022-01-01')
-    cy.get('.time').type('01:00')
-    cy.get('.description').type('inv')
-    cy.get('.submit-button').click()
-
-    cy.get('.notification').should('exist')
-    cy.get('.notification').should(
-      'have.text',
-      'Description must be over 5 characters.'
-    )
-  })
-
   it('shows error from backend when creating timeLog fails with data outside sprint', () => {
     cy.visit('/timelogs')
     cy.get('.timelogs-container-1').should('exist')

--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -151,7 +151,7 @@ describe('Time logs & sprints', () => {
     cy.get('#timelog-rows').children().should('have.length', 1)
   })
 
-    it('displays frontend notification from form with negative hours', () => {
+    it('displays error on time field of form when input is negative hours', () => {
       cy.visit('/timelogs')
       cy.get('.timelogs-container-1').should('exist')
       cy.get('.input-container').should('exist')
@@ -161,10 +161,10 @@ describe('Time logs & sprints', () => {
       cy.get('.submit-button').click()
 
       cy.get('.input-container').contains('Time must be in format HH:MM')
-      cy.get('.timelog-list').should('not.contain', 'negative time')
+      cy.get('#timelog-rows').should('not.contain', 'negative time')
     })
 
-    it('displays frontend notification from form with letters in hours', () => {
+    it('displays error on time field of form when input is letters', () => {
       cy.visit('/timelogs')
       cy.get('.timelogs-container-1').should('exist')
       cy.get('.input-container').should('exist')
@@ -174,10 +174,10 @@ describe('Time logs & sprints', () => {
       cy.get('.submit-button').click()
 
       cy.get('.input-container').contains('Time must be in format HH:MM')
-      cy.get('.timelog-list').should('not.contain', 'letters in time')
+      cy.get('#timelog-rows').should('not.contain', 'letters in time')
     })
 
-    it('displays frontend notification from form without colon in the middle', () => {
+    it('displays error on time field of form when input is missing a colon', () => {
       cy.visit('/timelogs')
       cy.get('.timelogs-container-1').should('exist')
       cy.get('.input-container').should('exist')
@@ -187,10 +187,10 @@ describe('Time logs & sprints', () => {
       cy.get('.submit-button').click()
 
       cy.get('.input-container').contains('Time must be in format HH:MM')
-      cy.get('.timelog-list').should('not.contain', 'missing colon')
+      cy.get('#timelog-rows').should('not.contain', 'missing colon')
     })
 
-    it('displays frontend notification from form with over 60 minutes', () => {
+    it('displays error on time field of form when input has over 60 minutes', () => {
       cy.visit('/timelogs')
       cy.get('.timelogs-container-1').should('exist')
       cy.get('.input-container').should('exist')
@@ -200,10 +200,10 @@ describe('Time logs & sprints', () => {
       cy.get('.submit-button').click()
 
       cy.get('.input-container').contains('Time must be in format HH:MM')
-      cy.get('.timelog-list').should('not.contain', 'over 60 minutes')
+      cy.get('#timelog-rows').should('not.contain', 'over 60 minutes')
     })
 
-    it('displays frontend notification from form with description under 5 characters', () => {
+    it('displays error on description field of form when input is under 5 characters long', () => {
       cy.visit('/timelogs')
       cy.get('.timelogs-container-1').should('exist')
       cy.get('.input-container').should('exist')
@@ -213,7 +213,7 @@ describe('Time logs & sprints', () => {
       cy.get('.submit-button').click()
 
       cy.get('.input-container').contains('Description must be at least 5 characters')
-      cy.get('.timelog-list').should('not.contain', '1234')
+      cy.get('#timelog-rows').should('not.contain', '1234')
     })
 
     it('remove sprints, should not display sprints or time logs', () => {

--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -194,6 +194,71 @@ describe('Time logs & sprints', () => {
     )
   })
 
+    it('displays frontend notification from form with negative hours', () => {
+      cy.visit('/timelogs')
+      cy.get('.timelogs-container-1').should('exist')
+      cy.get('.input-container').should('exist')
+      cy.get('.date').type('2022-01-01')
+      cy.get('.time').type('-01:00')
+      cy.get('.description').type('negative time')
+      cy.get('.submit-button').click()
+
+      cy.get('.input-container').contains('Time must be in format HH:MM')
+      cy.get('.timelog-list').should('not.contain', 'negative time')
+    })
+
+    it('displays frontend notification from form with letters in hours', () => {
+      cy.visit('/timelogs')
+      cy.get('.timelogs-container-1').should('exist')
+      cy.get('.input-container').should('exist')
+      cy.get('.date').type('2022-01-01')
+      cy.get('.time').type('aabee')
+      cy.get('.description').type('letters in time')
+      cy.get('.submit-button').click()
+
+      cy.get('.input-container').contains('Time must be in format HH:MM')
+      cy.get('.timelog-list').should('not.contain', 'letters in time')
+    })
+
+    it('displays frontend notification from form without colon in the middle', () => {
+      cy.visit('/timelogs')
+      cy.get('.timelogs-container-1').should('exist')
+      cy.get('.input-container').should('exist')
+      cy.get('.date').type('2022-01-01')
+      cy.get('.time').type('0100')
+      cy.get('.description').type('missing colon')
+      cy.get('.submit-button').click()
+
+      cy.get('.input-container').contains('Time must be in format HH:MM')
+      cy.get('.timelog-list').should('not.contain', 'missing colon')
+    })
+
+    it('displays frontend notification from form with over 60 minutes', () => {
+      cy.visit('/timelogs')
+      cy.get('.timelogs-container-1').should('exist')
+      cy.get('.input-container').should('exist')
+      cy.get('.date').type('2022-01-01')
+      cy.get('.time').type('01:61')
+      cy.get('.description').type('over 60 minutes')
+      cy.get('.submit-button').click()
+
+      cy.get('.input-container').contains('Time must be in format HH:MM')
+      cy.get('.timelog-list').should('not.contain', 'over 60 minutes')
+    })
+
+    it('displays frontend notification from form with description under 5 characters', () => {
+      cy.visit('/timelogs')
+      cy.get('.timelogs-container-1').should('exist')
+      cy.get('.input-container').should('exist')
+      cy.get('.date').type('2022-01-01')
+      cy.get('.time').type('01:00')
+      cy.get('.description').type('1234')
+      cy.get('.submit-button').click()
+
+      cy.get('.input-container').contains('Description must be at least 5 characters')
+      cy.get('.timelog-list').should('not.contain', '1234')
+    })
+
   after(() => {
     cy.deleteAllGroups()
   })

--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -168,32 +168,6 @@ describe('Time logs & sprints', () => {
     cy.get('#timelog-rows').children().should('have.length', 1)
   })
 
-  it('remove sprints, should not display sprints or time logs', () => {
-    cy.get('#hamburger-menu-button')
-      .click()
-      .then(() => {
-        cy.contains('Sprint Dashboard').click()
-      })
-
-    cy.get('.sprints-container')
-      .find('[id^="sprint-remove-button-"]')
-      .click({ multiple: true })
-      .then(() =>
-        cy.get('#app-content').should('not.contain', '.sprint-list-container')
-      )
-
-    cy.get('#hamburger-menu-button')
-      .click()
-      .then(() => {
-        cy.contains('Time Log').click()
-      })
-
-    cy.get('#app-content').should(
-      'contain',
-      'Your group has no sprints. Add a sprint using Sprint Dashboard.'
-    )
-  })
-
     it('displays frontend notification from form with negative hours', () => {
       cy.visit('/timelogs')
       cy.get('.timelogs-container-1').should('exist')
@@ -257,6 +231,32 @@ describe('Time logs & sprints', () => {
 
       cy.get('.input-container').contains('Description must be at least 5 characters')
       cy.get('.timelog-list').should('not.contain', '1234')
+    })
+
+    it('remove sprints, should not display sprints or time logs', () => {
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
+          cy.contains('Sprint Dashboard').click()
+        })
+
+      cy.get('.sprints-container')
+        .find('[id^="sprint-remove-button-"]')
+        .click({ multiple: true })
+        .then(() =>
+          cy.get('#app-content').should('not.contain', '.sprint-list-container')
+        )
+
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
+          cy.contains('Time Log').click()
+        })
+
+      cy.get('#app-content').should(
+        'contain',
+        'Your group has no sprints. Add a sprint using Sprint Dashboard.'
+      )
     })
 
   after(() => {

--- a/frontend/src/components/TimeLogsPage/TimeLogForm.js
+++ b/frontend/src/components/TimeLogsPage/TimeLogForm.js
@@ -7,6 +7,10 @@ export const TimeLogForm = ({ handleSubmit, disabled }) => {
   const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
   const [time, setTime] = useState('')
   const [description, setDescription] = useState('')
+  const [formTimeHasError, setFormTimeHasError] = useState(false)
+  const [timeErrorMessage, setTimeErrorMessage] = useState('')
+  const [formDescriptionHasError, setFormDescriptionHasError] = useState(false)
+  const [descriptionErrorMessage, setDescriptionErrorMessage] = useState('')
 
   const handleDateChange = (event) => {
     setDate(event.target.value)
@@ -20,10 +24,34 @@ export const TimeLogForm = ({ handleSubmit, disabled }) => {
     setDescription(event.target.value)
   }
 
+  const formIsInvalid = () => {
+    let error_exists = false
+    const timePattern = /^([0-1][0-9]|2[0-3]):[0-5][0-9]$/
+    if (!timePattern.test(time)) {
+      setFormTimeHasError(true)
+      setTimeErrorMessage('Time must be in format HH:MM')
+      error_exists = true
+    }
+    if (description.length < 5) {
+      setFormDescriptionHasError(true)
+      setDescriptionErrorMessage('Description must be at least 5 characters')
+      error_exists = true
+    }
+    return error_exists
+  }
+
   const handleFormSubmit = (event) => {
     event.preventDefault()
-    handleSubmit(date, time, description)
-    clearForm()
+    if (formIsInvalid()) {
+      return
+    } else {
+      setFormTimeHasError(false)
+      setTimeErrorMessage('')
+      setFormDescriptionHasError(false)
+      setDescriptionErrorMessage('')
+      handleSubmit(date, time, description)
+      clearForm()
+    }
   }
 
   const clearForm = () => {
@@ -51,6 +79,8 @@ export const TimeLogForm = ({ handleSubmit, disabled }) => {
         />
         <TextField
           disabled={disabled}
+          error={formTimeHasError}
+          helperText={formTimeHasError && timeErrorMessage}
           className="time"
           id="time"
           label="Time (HH:MM)"
@@ -64,6 +94,8 @@ export const TimeLogForm = ({ handleSubmit, disabled }) => {
         />
         <TextField
           disabled={disabled}
+          error={formDescriptionHasError}
+          helperText={formDescriptionHasError && descriptionErrorMessage}
           className="description"
           id="description"
           label="Description"


### PR DESCRIPTION
Closes #211

- Timelog page's form prevents submission if time-field doesn't fit the format HH:MM (through regular expression checking), or if decription-field has less than 5 characters.
- Previous backend test for short descriptions has been deleted, since it gets overshadowed in Cypress by the front-end's validation.
- Tests created for invalid time and description inputs
- A rebase resolving conflicts between this branch and Pull Request #212 was carried out.