### PR TITLE
Fix: clicking previous sprint selects the first sprint 

### DIFF
--- a/frontend/src/components/TimeLogsPage/TimeLogsPage.js
+++ b/frontend/src/components/TimeLogsPage/TimeLogsPage.js
@@ -149,8 +149,9 @@ const TimeLogsPage = (props) => {
 
   const handleClickPreviousSprint = () => {
     setSelectedSprintNumber(
-      existingSprintNumbers.find((sprint) => sprint < selectedSprintNumber) ||
-        selectedSprintNumber
+      [...existingSprintNumbers]
+        .reverse()
+        .find((sprint) => sprint < selectedSprintNumber) || selectedSprintNumber
     )
   }
 


### PR DESCRIPTION
- Fix: clicking previous sprint in Time Logs page selects the first sprint instead of the previous one