### PR TITLE
Add workflow for production deployment

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,0 +1,55 @@
+name: Deploy to staging
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build backend
+        id: build-backend
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: backend
+          tags: production ${{ github.sha }}
+          context: backend/
+          containerfiles: |
+            backend/Dockerfile
+
+      - name: Build frontend
+        id: build-frontend
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: frontend
+          tags: production ${{ github.sha }}
+          context: frontend/
+          containerfiles: |
+            frontend/Dockerfile
+
+      - name: Push backend to quay.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-backend.outputs.image }}
+          tags: ${{ steps.build-backend.outputs.tags }}
+          registry: quay.io/ohtuilmo
+          username: ohtuilmo+github
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Push frontend to quay.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-frontend.outputs.image }}
+          tags: ${{ steps.build-frontend.outputs.tags }}
+          registry: quay.io/ohtuilmo
+          username: ohtuilmo+github
+          password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
This PR adds new GitHub Actions workflow for production deployment.
- It triggers when there is a new release made in github
- The images get tag 'production'