### PR TITLE
Fix type error in NavigationBar, hide group from NavigationBar in small screens

### DIFF
--- a/frontend/src/components/common/NavigationBar.css
+++ b/frontend/src/components/common/NavigationBar.css
@@ -28,6 +28,16 @@
 .navigation-bar-groupname {
   padding-left: 5px;
   padding-right: 10px;
+
+  @media (max-width: 650px) {
+      display: none !important;
+  }
+}
+
+.navigation-bar-groupicon {
+  @media (max-width: 650px) {
+      display: none !important;
+    }
 }
 
 @media only screen and (max-width: 450px) {

--- a/frontend/src/components/common/NavigationBar.js
+++ b/frontend/src/components/common/NavigationBar.js
@@ -42,31 +42,45 @@ const NavigationBar = ({ group, user, history, logout }) => {
   }
 
   let groupname =
-    group && group.groupName
-      ? (
-        <h4 className="navigation-bar-groupname tracking-in-expand" data-cy="groupname_display_assigned" >
-          {group.groupName}
-        </h4>
-      )
-      : (
-        <h4 className="navigation-bar-groupname tracking-in-expand" data-cy="groupname_display_unassigned" >
-          No group assigned
-        </h4>
-      )
-  let username = user.user
-    ? (
+    group && group.groupName ? (
+      <h4
+        className="navigation-bar-groupname tracking-in-expand"
+        data-cy="groupname_display_assigned"
+      >
+        {group.groupName}
+      </h4>
+    ) : (
+      <h4
+        className="navigation-bar-groupname tracking-in-expand"
+        data-cy="groupname_display_unassigned"
+      >
+        No group assigned
+      </h4>
+    )
+  let username =
+    user && user.user ? (
       <h4 className="navigation-bar-username tracking-in-expand">
         {user.user.username}
       </h4>
+    ) : (
+      ''
     )
-    : ('')
 
-  let loggedIn = user && user.user ? <Fragment>
-    {!user.user.admin && !user.user.instructor ? <GroupIcon /> : ''}
-    {!user.user.admin && !user.user.instructor ? groupname : ''}
-    <AccountCircle />
-    {username}
-  </Fragment> : ''
+  let loggedIn =
+    user && user.user ? (
+      <Fragment>
+        {!user.user.admin && !user.user.instructor ? (
+          <GroupIcon className="navigation-bar-groupicon" />
+        ) : (
+          ''
+        )}
+        {!user.user.admin && !user.user.instructor ? groupname : ''}
+        <AccountCircle />
+        {username}
+      </Fragment>
+    ) : (
+      ''
+    )
 
   return (
     <div className="navigation-bar-container">
@@ -99,7 +113,7 @@ const NavigationBar = ({ group, user, history, logout }) => {
 const mapStateToProps = (state) => {
   return {
     user: state.login.user,
-    group: state.registrationDetails.myGroup
+    group: state.registrationDetails.myGroup,
   }
 }
 


### PR DESCRIPTION
resolves #223 

- Added `user && user.user` check to `let username` to fix the typeError when logging in:

```
Uncaught TypeError: Cannot read properties of null (reading 'user')
```

- Added styles to hide the group name from navigation bar on smaller screens as it was breaking the navigation bar when it didn't fit there.

