### PR TITLE
Fix issue causing topic pages to crash

### DIFF
--- a/frontend/src/components/TimeLogsPage/TimeLogsPage.css
+++ b/frontend/src/components/TimeLogsPage/TimeLogsPage.css
@@ -42,7 +42,6 @@
 
     .input-container {
         display: flex;
-        align-items: flex-end;
         flex-wrap: wrap;
         gap: 14px;
     }

--- a/frontend/src/components/ViewTopicPage.js
+++ b/frontend/src/components/ViewTopicPage.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
 import Topic from './Topic'
 import TopicEditPage from './TopicEditPage'
 import viewTopicPageActions from '../reducers/actions/viewTopicPageActions'
@@ -28,8 +29,7 @@ class ViewTopicPage extends React.Component {
   copyToConfiguration = async () => {
     // eslint-disable-next-line
     const ok = confirm('sure?')
-    console.log(this.props.topic.id )
-    if ( ok ) {
+    if (ok) {
       try {
         // eslint-disable-next-line
         const createdTopic = await topicService.copy(this.props.topic.id)
@@ -72,7 +72,7 @@ const mapStateToProps = (state) => {
     topic: state.viewTopicPage.topic,
     isEditable: state.viewTopicPage.isEditable,
     isOnEditMode: state.viewTopicPage.isOnEditMode,
-    user: state.login.user
+    user: state.login.user,
   }
 }
 
@@ -81,9 +81,6 @@ const mapDispatchToProps = {
   setSuccess: notificationActions.setSuccess,
 }
 
-const ConnectedViewTopicPage = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ViewTopicPage)
-
-export default ConnectedViewTopicPage
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ViewTopicPage)
+)


### PR DESCRIPTION
resolves #228 

- Fix issue causing topic pages to crash
- The issue was caused by the following error:

```
Unhandled Rejection (TypeError): Cannot read properties of undefined (reading 'params')
  10 | class ViewTopicPage extends React.Component {
  11 |   async componentDidMount() {
> 12 |     const id = this.props.match.params.id
```

- The [React Router match object](https://v5.reactrouter.com/web/api/match) was not passed to the `ViewTopicPage` as a prop which caused the issue.
- Fixed the issue by importing [withRouter](https://v5.reactrouter.com/web/api/withRouter) which provides the `match` object as a prop (not sure how this worked before 🤔 ).
- Also, removed `align-items: flex-end;` from `TimeLogsPage.css` as it caused the form inputs to move upwards when a validation error message was rendered below the input field.
