### PR TITLE
Fix/timelog del confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ohtuilmo
 
 [![CI](https://github.com/Ohtuilmo/ohtuilmo/actions/workflows/staging.yaml/badge.svg)](https://github.com/Ohtuilmo/ohtuilmo/actions/workflows/staging.yaml)
-[![Ohtuilmo](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/detailed/2e43ni&style=flat&logo=cypress)](https://cloud.cypress.io/projects/2e43ni/runs)
+[![Ohtuilmo](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/detailed/2e43ni/main&style=flat&logo=cypress)](https://cloud.cypress.io/projects/2e43ni/runs)
 
 ## Project links
 

--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -126,6 +126,34 @@ describe('Time logs & sprints', () => {
     cy.get('#timelog-rows').should('contain', 'No logs yet :(')
   })
 
+  it('asks for confirmation before deleting a time log and aborts deletion when canceled', () => {
+    cy.get('#hamburger-menu-button')
+    .click()
+    .then(() => {
+      cy.contains('Time Log').click()
+    })
+
+    cy.get(':nth-child(1) > .timelogs-description')
+      .invoke('text')
+      .as('testedLogDescription')
+
+    cy.get('#timelog-rows > :nth-child(1)')
+      .find('[id^="timelog-remove-button-"]')
+      .click()
+
+    cy.get('.confirmation-dialog').should(
+      'contain',
+      'Delete this time log? It cannot be restored.'
+    )
+    cy.get('.confirmation-dialog').find('#confirmation-dialog-no-button').click()
+    cy.get('@testedLogDescription').then((testedLogDescription) => {
+      cy.get('#timelog-rows > :nth-child(1) > .timelogs-description').contains(
+        testedLogDescription
+      )
+    })
+    cy.get('#timelog-rows').children().should('have.length', 2)
+  })
+
   it('remove a time log, should not display removed time log', () => {
     cy.get('#hamburger-menu-button')
       .click()
@@ -140,6 +168,12 @@ describe('Time logs & sprints', () => {
     cy.get('#timelog-rows > :nth-child(1)')
       .find('[id^="timelog-remove-button-"]')
       .click()
+
+    cy.get('.confirmation-dialog').should(
+      'contain',
+      'Delete this time log? It cannot be restored.'
+    )
+    cy.get('.confirmation-dialog').find('#confirmation-dialog-yes-button').click()
 
     cy.get('@removedLogDescription').then((removedLogDescription) => {
       cy.get('#timelog-rows > :nth-child(1) > .timelogs-description').should(

--- a/frontend/src/components/TimeLogsPage/TimeLogRow.js
+++ b/frontend/src/components/TimeLogsPage/TimeLogRow.js
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { minutesToFormattedHoursAndMinutes } from '../../utils/functions'
 import { DeleteOutlineRounded } from '@material-ui/icons'
 import { IconButton } from '@material-ui/core'
+import ConfirmationDialog from '../common/ConfirmationDialog'
 
 import './TimeLogsPage.css'
 
 export const TimeLogRow = ({ log, handleDelete }) => {
   const { hours, minutes } = minutesToFormattedHoursAndMinutes(log.minutes)
+  const [confirmOpen, setConfirmOpen] = useState(false)
 
   return (
     <div className="timelogs-table-row">
@@ -24,10 +26,18 @@ export const TimeLogRow = ({ log, handleDelete }) => {
         className="timelogs-remove-button"
         style={{ padding: '0 12px' }}
         disableRipple
-        onClick={handleDelete}
+        onClick={() => setConfirmOpen(true)}
       >
         <DeleteOutlineRounded />
       </IconButton>
+      <ConfirmationDialog
+        title="Delete Time Log?"
+        open={confirmOpen}
+        setOpen={setConfirmOpen}
+        onConfirm={handleDelete}
+      >
+        Delete this time log? It cannot be restored.
+      </ConfirmationDialog>
     </div>
   )
 }

--- a/frontend/src/components/TopicForm.js
+++ b/frontend/src/components/TopicForm.js
@@ -88,11 +88,11 @@ const TopicForm = (props) => {
             onChange={(e) => props.updateSpecialRequests(e.target.value)}
           />
         </div>
-        {false&&<div >
+        {<div >
           Kerro seuraavassa kohdassa myös sopivat ajankohdat / tell also what is the suitable timing for your project
           <ul>
-            <li>alkukesä / early summer 15.5.-30.6.</li>
-            <li>koko kesän projekti / whole summer 15.5.-30.8.</li>
+            <li>alkukesä / early summer 12.5.-28.6.</li>
+            <li>koko kesän projekti / whole summer 13.5.-30.8.</li>
           </ul>
         </div>}
         <div>

--- a/frontend/src/components/common/ConfirmationDialog.js
+++ b/frontend/src/components/common/ConfirmationDialog.js
@@ -1,0 +1,43 @@
+import React from "react"
+import Button from "@material-ui/core/Button"
+import Dialog from "@material-ui/core/Dialog"
+import DialogActions from "@material-ui/core/DialogActions"
+import DialogContent from "@material-ui/core/DialogContent"
+import DialogTitle from "@material-ui/core/DialogTitle"
+
+const ConfirmationDialog = (props) => {
+  const { title, children, open, setOpen, onConfirm } = props
+  return (
+    <Dialog
+      open={open}
+      onClose={() => setOpen(false)}
+      className="confirmation-dialog"
+    >
+      <DialogTitle id="confirmation-dialog">{title}</DialogTitle>
+      <DialogContent>{children}</DialogContent>
+      <DialogActions>
+        <Button
+          id="confirmation-dialog-no-button"
+          variant="contained"
+          onClick={() => setOpen(false)}
+          color="secondary"
+        >
+          No
+        </Button>
+        <Button
+          id="confirmation-dialog-yes-button"
+          variant="contained"
+          onClick={() => {
+            setOpen(false)
+            onConfirm()
+          }}
+          color="default"
+        >
+          Yes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ConfirmationDialog

--- a/frontend/src/components/common/ConfirmationDialog.js
+++ b/frontend/src/components/common/ConfirmationDialog.js
@@ -1,9 +1,9 @@
-import React from "react"
-import Button from "@material-ui/core/Button"
-import Dialog from "@material-ui/core/Dialog"
-import DialogActions from "@material-ui/core/DialogActions"
-import DialogContent from "@material-ui/core/DialogContent"
-import DialogTitle from "@material-ui/core/DialogTitle"
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
 
 const ConfirmationDialog = (props) => {
   const { title, children, open, setOpen, onConfirm } = props


### PR DESCRIPTION
Closes #201 

* New, reusable component ConfirmationDialog created to enable confirmation messages
* User is prompted to confirm their choice when trying to delete a time log entry
* Test created to check that the confirmation window works and prevents deletion when user cancels their decision
* Existing test updated to account for the confirmation window when deleting a time log entry