### PR TITLE
Prevent caching for login and logout

### DIFF
--- a/backend/controllers/login.js
+++ b/backend/controllers/login.js
@@ -14,6 +14,7 @@ loginRouter.post('/', async (req, res) => {
   if (!req.headers.hypersonstudentid)
     return res
       .status(401)
+      .set('Cache-Control', 'no-store')
       .json({ error: 'Student number missing from headers.' })
       .end()
 
@@ -29,7 +30,7 @@ loginRouter.post('/', async (req, res) => {
           { id: foundUser.student_number, admin: foundUser.admin },
           config.secret
         )
-        return res.status(200).json({
+        return res.status(200).set('Cache-Control', 'no-store').json({
           token,
           user: foundUser,
         })
@@ -48,7 +49,7 @@ loginRouter.post('/', async (req, res) => {
               { id: savedUser.student_number, admin: savedUser.admin },
               config.secret
             )
-            return res.status(200).json({
+            return res.status(200).set('Cache-Control', 'no-store').json({
               token,
               user: savedUser,
             })

--- a/backend/controllers/logout.js
+++ b/backend/controllers/logout.js
@@ -2,7 +2,9 @@ const logoutRouter = require('express').Router()
 
 const handleDatabaseError = (res, error) => {
   console.log(error)
-  res.status(500).json({ error: 'Something is wrong... try reloading the page' })
+  res
+    .status(500)
+    .json({ error: 'Something is wrong... try reloading the page' })
 }
 
 logoutRouter.post('/', async (req, res) => {
@@ -12,11 +14,13 @@ logoutRouter.post('/', async (req, res) => {
     if (logoutUrl) {
       return res
         .status(200)
+        .set('Cache-Control', 'no-store')
         .send({ logoutUrl: `${logoutUrl}?return=${returnUrl}` })
         .end()
     }
     res
       .status(200)
+      .set('Cache-Control', 'no-store')
       .send({ logoutUrl: returnUrl })
       .end()
   } catch (error) {


### PR DESCRIPTION
resolves #221

This is an attempt to fix the log out bug.

**Here's the HTTP request when everything works and the page redirects to the Shibboleth login page:**

<img width="462" alt="Screenshot 2024-04-08 at 16 14 37" src="https://github.com/Ohtuilmo/ohtuilmo/assets/84803085/294f2580-feed-4f0f-a89e-173800b7b7da">

**Here's the HTTP request after log out, when the page doesn't work properly and the user is not redirected to the Shibboleth login page:**

<img width="459" alt="Screenshot 2024-04-08 at 16 14 28" src="https://github.com/Ohtuilmo/ohtuilmo/assets/84803085/7b700e41-4bc1-4d1b-8e5c-d9794511f058">

-----

The screenshots seem to indicate the issue has to do with caching of the login responses. I disabled caching for login/logout API's (as far as I understand these prolly shouldn't be cached anyway).

This fix is hard to test in dev environment as we haven't implemented the Shibboleth login there. So need to still try it out in production to verify it fixes the bug.
