### PR TITLE
Specify node version in package.json

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Read backend node version from package.json
         uses: skjnldsv/read-package-engines-version-actions@v2
         with:
-          path: ./backend/package.json
+          path: ./backend/
         id: backend-engines
 
       - name: Setup Node.js for backend
@@ -34,7 +34,7 @@ jobs:
       - name: Read frontend node version from package.json
         uses: skjnldsv/read-package-engines-version-actions@v2
         with:
-          path: ./frontend/package.json
+          path: ./frontend/
         id: frontend-engines
 
       - name: Setup Node.js for frontend
@@ -56,7 +56,7 @@ jobs:
       - name: Read backend node version from package.json
         uses: skjnldsv/read-package-engines-version-actions@v2
         with:
-          path: ./backend/package.json
+          path: ./backend/
         id: backend-engines
 
       - name: Setup Node.js for initializing db with backend's npm scripts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,16 +14,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Read backend node version from package.json
+        uses: skjnldsv/read-package-engines-version-actions@v2
+        with:
+          path: ./backend/package.json
+        id: backend-engines
+
+      - name: Setup Node.js for backend
         uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: ${{ steps.backend-engines.outputs.nodeVersion }}
 
       - name: Install backend dependencies & run linter
         working-directory: ./backend
         run: |
           npm install
           npm run lint
+
+      - name: Read frontend node version from package.json
+        uses: skjnldsv/read-package-engines-version-actions@v2
+        with:
+          path: ./frontend/package.json
+        id: frontend-engines
+
+      - name: Setup Node.js for frontend
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.frontend-engines.outputs.nodeVersion }}
 
       - name: Install frontend dependencies & run linter
         working-directory: ./frontend
@@ -36,10 +53,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Read backend node version from package.json
+        uses: skjnldsv/read-package-engines-version-actions@v2
+        with:
+          path: ./backend/package.json
+        id: backend-engines
+
+      - name: Setup Node.js for initializing db with backend's npm scripts
         uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: ${{ steps.backend-engines.outputs.nodeVersion }}
 
       - name: Start db container
         run: docker compose -f compose.ci.yaml up db -d

--- a/backend/package.json
+++ b/backend/package.json
@@ -57,5 +57,8 @@
     "hooks": {
       "pre-commit": "npm test"
     }
+  },
+  "engines": {
+    "node": "12"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,5 +53,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "engines": {
+    "node": "10"
+  }
 }


### PR DESCRIPTION
This PR adds node version used to package.json. It's good practice for developing with node.

Additionally, GitHub Actions is changed to read node versions required from package.json. This will simplify node version updates.