### PR TITLE
Fix typeError in administration/users page

### DIFF
--- a/frontend/src/utils/userMapper.js
+++ b/frontend/src/utils/userMapper.js
@@ -32,7 +32,10 @@ const mapSemesterField = (content) => {
       break
     }
   }
-  parts[1] = content.match(yearPattern)[0]
+
+  const matchedYear = content.match(yearPattern)
+  parts[1] = matchedYear ? matchedYear[0] : ''
+
   return `${parts[1]} ${parts[0]}`
 }
 


### PR DESCRIPTION
Navigating to the `administration/users` page resulted in the following error:

```
Unhandled Rejection (TypeError): Cannot read properties of null (reading '0')
mapSemesterField
src/utils/userMapper.js:35
  32 |       break
  33 |     }
  34 |   }
> 35 |   parts[1] = content.match(yearPattern)[0]
  36 |   return `${parts[1]} ${parts[0]}`
  37 | }
  38 | 
```

Fixed this by using the conditional operator.