### PR TITLE
Instructor page group filter

### DIFF
--- a/backend/seeders/20240319112824-add-new-users-and-topics.js
+++ b/backend/seeders/20240319112824-add-new-users-and-topics.js
@@ -313,7 +313,7 @@ module.exports = {
     await query.bulkDelete('configurations', { name: ['Kevät 2024', 'Syksy 2023', 'Kevät 2023'] }, {})
     await query.bulkDelete('users', { username: ['olliohj', 'newuser1', 'johnsmith', 'jane.madison', 'instruct1', 'timoTekoäly', 'johannakoodari'] }, {})
     await query.bulkDelete('groups', { name: ['ohtuilmo-ryhmä', 'tekOäly-ryhmä'] }, {})
-    await query.bulkDelete('group_students', { group_id: 1 }, {})
+    await query.bulkDelete('group_students', { group_id: [1, 2] }, {})
     await query.bulkDelete('registrations', { student_student_number: ['112345700', '112345701', '112345702', '112345704', '112345705'] }, {})
   }
 }

--- a/backend/seeders/20240319112824-add-new-users-and-topics.js
+++ b/backend/seeders/20240319112824-add-new-users-and-topics.js
@@ -250,7 +250,13 @@ const newGroup = [
     topic_id: 5,
     configuration_id: 1,
     instructor_id: 112345703 ,
-  }
+  },
+  {
+    name: 'ohtuilmo-ryhmä2',
+    topic_id: 6,
+    configuration_id: 2,
+    instructor_id: 112345699,
+  },
 ]
 
 const group_students = [

--- a/frontend/e2e/cypress/integration/instructorPage.spec.js
+++ b/frontend/e2e/cypress/integration/instructorPage.spec.js
@@ -289,6 +289,29 @@ describe('Instructor page', () => {
     cy.contains('4.50')
   })
 
+  it('is loaded displaying all groups of a configuration', () => {
+    cy.get('[data-cy=configuration-selector]').click()
+    cy.get('.configuration-menu-item').contains('Konfiguraatio 1').click()
+    cy.contains('Tykittelijät')
+    cy.contains('Kakkostykitys')
+  })
+
+  it('can filter and display only one group at a time', () => {
+    cy.get('[data-cy=configuration-selector]').click()
+    cy.get('.configuration-menu-item').contains('Konfiguraatio 1').click()
+
+    cy.get('[data-cy=group-selector]').click()
+    cy.get('.specified-group-menu-item').contains('Tykittelijät').click()
+    cy.contains('Tykittelijät')
+    cy.should('not.contain', 'Kakkostykitys')
+
+    cy.get('[data-cy=group-selector]').click()
+    cy.get('.specified-group-menu-item').contains('Kakkostykitys').click()
+    cy.contains('Kakkostykitys')
+    cy.should('not.contain', 'Tykittelijät')
+  })
+
+
   after(() => {
     cy.deleteAllGroups()
     cy.deleteAllPeerReviews()

--- a/frontend/e2e/cypress/integration/instructorPage.spec.js
+++ b/frontend/e2e/cypress/integration/instructorPage.spec.js
@@ -10,6 +10,14 @@ const initTests = () => {
   })
 
   cy.createGroup({
+    name: 'Kakkostykitys',
+    topicId: 3,
+    configurationId: 1,
+    instructorId: '012345688',
+    studentIds: ['012345678', '012345698'],
+  })
+
+  cy.createGroup({
     name: 'Kämmäilijät',
     topicId: 2,
     configurationId: 2,

--- a/frontend/e2e/cypress/integration/instructorPage.spec.js
+++ b/frontend/e2e/cypress/integration/instructorPage.spec.js
@@ -255,8 +255,10 @@ const initTests = () => {
   cy.createPeerReviews(konf2vastaukset1)
 }
 
-describe('Instructor review page', () => {
+describe('Instructor page', () => {
   before(() => {
+    cy.deleteAllGroups()
+    cy.deleteAllPeerReviews()
     initTests()
   })
 
@@ -265,7 +267,7 @@ describe('Instructor review page', () => {
     cy.visit('/instructorpage')
   })
 
-  it('Starting testing', () => {
+  it('shows correct url, contains configuration selector and displays its group', () => {
     // submit not successfull, still on same page
     cy.url().should('contain', '/instructorpage')
     cy.get('[data-cy=configuration-selector]').click()
@@ -274,7 +276,7 @@ describe('Instructor review page', () => {
     cy.contains('2.50')
   })
 
-  it('Change configuration twice', () => {
+  it('displays the corresponding groups of each configuration', () => {
     // submit not successfull, still on same page
     cy.get('[data-cy=configuration-selector]').click()
     cy.get('.configuration-menu-item').contains('Konfiguraatio 2').click()

--- a/frontend/src/components/InstructorPage.css
+++ b/frontend/src/components/InstructorPage.css
@@ -24,3 +24,9 @@
   padding: 0;
   text-align: center;
 }
+.selector-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  flex-wrap: wrap;
+}

--- a/frontend/src/components/InstructorPage.jsx
+++ b/frontend/src/components/InstructorPage.jsx
@@ -36,7 +36,7 @@ const GroupDetails = ({ myGroup }) => {
   }
 }
 
-const Answers = ({ answers, currentConfiguration }) => {
+const Answers = ({ answers, currentConfiguration, currentGroupID }) => {
   answers = answers.filter(
     (group) => group.group.configurationId === currentConfiguration
   )
@@ -270,12 +270,16 @@ const ConfigurationSelect = ({
   currentConfiguration,
   setCurrentConfiguration,
   configurations,
+  setCurrentGroupID
 }) => {
   return (
     <Select
       data-cy="configuration-selector"
       value={currentConfiguration}
-      onChange={(e) => setCurrentConfiguration(e.target.value)}
+      onChange={(e) => {
+        setCurrentConfiguration(e.target.value)
+        setCurrentGroupID('0')
+      }}
     >
       {configurations.map((configuration) => (
         <MenuItem
@@ -297,14 +301,21 @@ const GroupSelectWrapper = ({ label, children }) => (
   </div>
 )
 
-const GroupSelect = ({ currentGroupID, setCurrentGroupID, allGroups }) => {
+const GroupSelect = ({ currentGroupID, setCurrentGroupID, allGroupsInConfig }) => {
   return (
     <Select
       data-cy='group-selector'
       value={currentGroupID}
       onChange={(e) => setCurrentGroupID(e.target.value)}
     >
-      {allGroups.map((group) => (
+      <MenuItem
+        key={0}
+        className='all-groups-menu-item'
+        value={'0'}
+      >
+        All groups
+      </MenuItem>
+      {allGroupsInConfig.map((group) => (
         <MenuItem
           key={group.id}
           className='specified-group-menu-item'
@@ -377,21 +388,24 @@ const InstructorPage = (props) => {
         jsonData={JSON.stringify(answers)}
         fileName="peerReviews.json"
       />
-      <ConfigurationSelectWrapper label="Select configuration">
-        <ConfigurationSelect
-          currentConfiguration={currentConfiguration}
-          setCurrentConfiguration={setCurrentConfiguration}
-          configurations={configurations}
-        />
-      </ConfigurationSelectWrapper>
-      <GroupSelectWrapper label="Select displayed group">
-        <GroupSelect
-          currentGroup={currentGroup}
-          setCurrentGroup={setCurrentGroup}
-          allGroups={groups}
-        />
-      </GroupSelectWrapper>
-      <Answers answers={answers} currentConfiguration={currentConfiguration} />
+      <div className="selector-container">
+        <ConfigurationSelectWrapper label="Select configuration">
+          <ConfigurationSelect
+            currentConfiguration={currentConfiguration}
+            setCurrentConfiguration={setCurrentConfiguration}
+            configurations={configurations}
+            setCurrentGroupID={setCurrentGroupID}
+          />
+        </ConfigurationSelectWrapper>
+        <GroupSelectWrapper label="Select displayed group">
+          <GroupSelect
+            currentGroupID={currentGroupID}
+            setCurrentGroupID={setCurrentGroupID}
+            allGroupsInConfig={groups.filter(group => group.configurationId === currentConfiguration)}
+          />
+        </GroupSelectWrapper>
+      </div>
+      <Answers answers={answers} currentConfiguration={currentConfiguration} currentGroupID={currentGroupID}/>
     </div>
   )
 }

--- a/frontend/src/components/InstructorPage.jsx
+++ b/frontend/src/components/InstructorPage.jsx
@@ -290,6 +290,35 @@ const ConfigurationSelect = ({
   )
 }
 
+const GroupSelectWrapper = ({ label, children }) => (
+  <div style={{ padding: 20 }}>
+    <Typography variant='caption'>{label}</Typography>
+    {children}
+  </div>
+)
+
+const GroupSelect = ({ currentGroup, setCurrentGroup, allGroups }) => {
+  console.log('groups', allGroups)
+  console.log('groupselect:', currentGroup)
+  return (
+    <Select
+      data-cy='group-selector'
+      value={currentGroup}
+      onChange={(e) => setCurrentGroup(e.target.value)}
+    >
+      {allGroups.map((group) => (
+        <MenuItem
+          key={group.id}
+          className='specified-group-menu-item'
+          value={group.id}
+        >
+          {group.name}
+        </MenuItem>
+      ))}
+    </Select>
+  )
+}
+
 const getUniqueConfigurations = (groups) => {
   const uniqueLookup = groups.reduce((configurations, group) => {
     return {
@@ -309,9 +338,13 @@ const InstructorPage = (props) => {
     answers,
     currentConfiguration,
     configurations,
+    currentGroup,
+    groups,
     setAnswers,
     setConfigurations,
     setCurrentConfiguration,
+    setGroups,
+    setCurrentGroup,
     setError,
   } = props
 
@@ -319,13 +352,14 @@ const InstructorPage = (props) => {
     const fetchData = async () => {
       try {
         const peerReviewData = await peerReviewService.getAnswersByInstructor()
-        const uniqueConfigurations = getUniqueConfigurations(
-          peerReviewData.map((data) => data.group)
-        )
+        const groupsData = peerReviewData.map((data) => data.group)
+        const uniqueConfigurations = getUniqueConfigurations(groupsData)
 
         setAnswers(peerReviewData)
         setConfigurations(uniqueConfigurations.reverse())
         setCurrentConfiguration(uniqueConfigurations[0].id)
+        setGroups(groupsData)
+        setCurrentGroup(groupsData[0].name)
       } catch (err) {
         console.error('error happened', err, err.response)
         setError('Something is wrong... try reloading the page')
@@ -333,9 +367,9 @@ const InstructorPage = (props) => {
     }
 
     fetchData()
-  }, [setAnswers, setConfigurations, setCurrentConfiguration, setError])
+  }, [setAnswers, setConfigurations, setCurrentConfiguration, setError, setGroups, setCurrentGroup])
 
-  if (!answers || !currentConfiguration) {
+  if (!answers || !currentConfiguration || !groups || !currentGroup) {
     return <div className="instructor-container">Loading</div>
   }
 
@@ -352,6 +386,13 @@ const InstructorPage = (props) => {
           configurations={configurations}
         />
       </ConfigurationSelectWrapper>
+      <GroupSelectWrapper label="Select displayed group">
+        <GroupSelect
+          currentGroup={currentGroup}
+          setCurrentGroup={setCurrentGroup}
+          allGroups={groups}
+        />
+      </GroupSelectWrapper>
       <Answers answers={answers} currentConfiguration={currentConfiguration} />
     </div>
   )
@@ -362,6 +403,8 @@ const mapStateToProps = (state) => {
     configurations: state.instructorPage.configurations,
     currentConfiguration: state.instructorPage.currentConfiguration,
     answers: state.instructorPage.answers,
+    groups: state.instructorPage.groups,
+    currentGroup: state.instructorPage.currentGroup
   }
 }
 
@@ -370,6 +413,8 @@ const mapDispatchToProps = {
   setCurrentConfiguration: instructorPageActions.setCurrentConfiguration,
   setAnswers: instructorPageActions.setAnswers,
   setError: notificationActions.setError,
+  setGroups: instructorPageActions.setGroups,
+  setCurrentGroup: instructorPageActions.setCurrentGroup
 }
 
 const ConnectedInstructorPage = connect(

--- a/frontend/src/components/InstructorPage.jsx
+++ b/frontend/src/components/InstructorPage.jsx
@@ -44,45 +44,50 @@ const Answers = ({ answers, currentConfiguration, currentGroupID }) => {
   return (
     <div>
       {answers.map((projectGroup, index) => {
-        return (
-          <div key={index}>
-            <hr />
-            <br />
-            <h1>{projectGroup.group.name}</h1>
-            <h3>Instructor: {projectGroup.group.instructorName}</h3>
-            <GroupDetails myGroup={projectGroup.group.studentNames} />
+        if (currentGroupID === projectGroup.group.id || currentGroupID === '0') {
+          return (
+            <div key={index}>
+              <hr />
+              <br />
+              <h1>{projectGroup.group.name}</h1>
+              <h3>Instructor: {projectGroup.group.instructorName}</h3>
+              <GroupDetails myGroup={projectGroup.group.studentNames} />
 
-            {projectGroup.round1Answers.length > 0 ? (
-              <div>
-                <h2>Peer review answers from the first round.</h2>
-                <GroupAnswers
-                  answers={projectGroup.round1Answers}
-                  students={projectGroup.group.studentNames}
-                />
-              </div>
-            ) : (
-              <h2>
-                This group hasn't answered to the first peer review round yet.
-              </h2>
-            )}
+              {projectGroup.round1Answers.length > 0 ? (
+                <div>
+                  <h2>Peer review answers from the first round.</h2>
+                  <GroupAnswers
+                    answers={projectGroup.round1Answers}
+                    students={projectGroup.group.studentNames}
+                  />
+                </div>
+              ) : (
+                <h2>
+                  This group hasn't answered to the first peer review round yet.
+                </h2>
+              )}
 
-            {projectGroup.round2Answers.length > 0 ? (
-              <div>
-                <h2>Peer review answers from the second round.</h2>
-                <GroupAnswers
-                  answers={projectGroup.round2Answers}
-                  students={projectGroup.group.studentNames}
-                />
-              </div>
-            ) : (
-              <h2>
-                This group hasn't answered to the second peer review round yet.
-              </h2>
-            )}
+              {projectGroup.round2Answers.length > 0 ? (
+                <div>
+                  <h2>Peer review answers from the second round.</h2>
+                  <GroupAnswers
+                    answers={projectGroup.round2Answers}
+                    students={projectGroup.group.studentNames}
+                  />
+                </div>
+              ) : (
+                <h2>
+                  This group hasn't answered to the second peer review round yet.
+                </h2>
+              )}
 
-            <br />
-          </div>
-        )
+              <br />
+            </div>
+          )
+          }
+          else {
+            return (<div></div>)
+          }
       })}
     </div>
   )

--- a/frontend/src/components/InstructorPage.jsx
+++ b/frontend/src/components/InstructorPage.jsx
@@ -297,14 +297,14 @@ const GroupSelectWrapper = ({ label, children }) => (
   </div>
 )
 
-const GroupSelect = ({ currentGroup, setCurrentGroup, allGroups }) => {
+const GroupSelect = ({ currentGroupID, setCurrentGroupID, allGroups }) => {
   console.log('groups', allGroups)
-  console.log('groupselect:', currentGroup)
+  console.log('groupselect:', currentGroupID)
   return (
     <Select
       data-cy='group-selector'
-      value={currentGroup}
-      onChange={(e) => setCurrentGroup(e.target.value)}
+      value={currentGroupID}
+      onChange={(e) => setCurrentGroupID(e.target.value)}
     >
       {allGroups.map((group) => (
         <MenuItem
@@ -338,13 +338,13 @@ const InstructorPage = (props) => {
     answers,
     currentConfiguration,
     configurations,
-    currentGroup,
+    currentGroupID,
     groups,
     setAnswers,
     setConfigurations,
     setCurrentConfiguration,
     setGroups,
-    setCurrentGroup,
+    setCurrentGroupID,
     setError,
   } = props
 
@@ -359,7 +359,7 @@ const InstructorPage = (props) => {
         setConfigurations(uniqueConfigurations.reverse())
         setCurrentConfiguration(uniqueConfigurations[0].id)
         setGroups(groupsData)
-        setCurrentGroup(groupsData[0].name)
+        setCurrentGroupID('0')
       } catch (err) {
         console.error('error happened', err, err.response)
         setError('Something is wrong... try reloading the page')
@@ -367,9 +367,9 @@ const InstructorPage = (props) => {
     }
 
     fetchData()
-  }, [setAnswers, setConfigurations, setCurrentConfiguration, setError, setGroups, setCurrentGroup])
+  }, [setAnswers, setConfigurations, setCurrentConfiguration, setError, setGroups, setCurrentGroupID])
 
-  if (!answers || !currentConfiguration || !groups || !currentGroup) {
+  if (!answers || !currentConfiguration || !groups || !currentGroupID) {
     return <div className="instructor-container">Loading</div>
   }
 
@@ -404,7 +404,7 @@ const mapStateToProps = (state) => {
     currentConfiguration: state.instructorPage.currentConfiguration,
     answers: state.instructorPage.answers,
     groups: state.instructorPage.groups,
-    currentGroup: state.instructorPage.currentGroup
+    currentGroupID: state.instructorPage.currentGroupID
   }
 }
 
@@ -414,7 +414,7 @@ const mapDispatchToProps = {
   setAnswers: instructorPageActions.setAnswers,
   setError: notificationActions.setError,
   setGroups: instructorPageActions.setGroups,
-  setCurrentGroup: instructorPageActions.setCurrentGroup
+  setCurrentGroupID: instructorPageActions.setCurrentGroupID
 }
 
 const ConnectedInstructorPage = connect(

--- a/frontend/src/components/InstructorPage.jsx
+++ b/frontend/src/components/InstructorPage.jsx
@@ -170,7 +170,7 @@ const RadioAnswer = ({ answers, questionNumber, students }) => {
         <thead>
           <tr className="radio-inforow">
             <th />
-            <th colspan={peers.length} className="radio-infoheader">
+            <th colSpan={peers.length} className="radio-infoheader">
               Reviewers
             </th>
             <th />

--- a/frontend/src/components/InstructorPage.jsx
+++ b/frontend/src/components/InstructorPage.jsx
@@ -298,8 +298,6 @@ const GroupSelectWrapper = ({ label, children }) => (
 )
 
 const GroupSelect = ({ currentGroupID, setCurrentGroupID, allGroups }) => {
-  console.log('groups', allGroups)
-  console.log('groupselect:', currentGroupID)
   return (
     <Select
       data-cy='group-selector'

--- a/frontend/src/reducers/actions/instructorPageActions.js
+++ b/frontend/src/reducers/actions/instructorPageActions.js
@@ -11,6 +11,7 @@ const setCurrentConfiguration = (configurationNumber) => {
     payload: configurationNumber
   }
 }
+
 const setAnswers = (answers) => {
   return {
     type: 'SET_INSTRUCTORPAGE_CURRENT_ANSWERS',
@@ -18,4 +19,18 @@ const setAnswers = (answers) => {
   }
 }
 
-export default { setCurrentConfiguration, setConfigurations, setAnswers }
+const setGroups = (groups) => {
+  return {
+    type: 'SET_INSTRUCTORPAGE_GROUPS',
+    payload: groups
+  }
+}
+
+const setCurrentGroup = (groupName) => {
+  return {
+    type: 'SET_INSTRUCTORPAGE_CURRENT_GROUP',
+    payload: groupName
+  }
+}
+
+export default { setCurrentConfiguration, setConfigurations, setAnswers, setCurrentGroup, setGroups }

--- a/frontend/src/reducers/actions/instructorPageActions.js
+++ b/frontend/src/reducers/actions/instructorPageActions.js
@@ -26,11 +26,11 @@ const setGroups = (groups) => {
   }
 }
 
-const setCurrentGroup = (groupName) => {
+const setCurrentGroupID = (groupId) => {
   return {
-    type: 'SET_INSTRUCTORPAGE_CURRENT_GROUP',
-    payload: groupName
+    type: 'SET_INSTRUCTORPAGE_CURRENT_GROUP_ID',
+    payload: groupId
   }
 }
 
-export default { setCurrentConfiguration, setConfigurations, setAnswers, setCurrentGroup, setGroups }
+export default { setCurrentConfiguration, setConfigurations, setAnswers, setCurrentGroupID, setGroups }

--- a/frontend/src/reducers/instructorPageReducer.js
+++ b/frontend/src/reducers/instructorPageReducer.js
@@ -1,7 +1,9 @@
 const initialState = {
   configurations: [],
   currentConfiguration: null,
-  answers: null
+  answers: null,
+  groups: [],
+  currentGroup: null
 }
 const instructorPageReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -19,6 +21,16 @@ const instructorPageReducer = (state = initialState, action) => {
     return {
       ...state,
       answers: action.payload
+    }
+  case 'SET_INSTRUCTORPAGE_GROUPS':
+    return {
+      ...state,
+      groups: action.payload
+    }
+  case 'SET_INSTRUCTORPAGE_CURRENT_GROUP':
+    return {
+      ...state,
+      currentGroup: action.payload
     }
   default:
     return state

--- a/frontend/src/reducers/instructorPageReducer.js
+++ b/frontend/src/reducers/instructorPageReducer.js
@@ -27,10 +27,10 @@ const instructorPageReducer = (state = initialState, action) => {
       ...state,
       groups: action.payload
     }
-  case 'SET_INSTRUCTORPAGE_CURRENT_GROUP':
+  case 'SET_INSTRUCTORPAGE_CURRENT_GROUP_ID':
     return {
       ...state,
-      currentGroup: action.payload
+      currentGroupID: action.payload
     }
   default:
     return state


### PR DESCRIPTION
Closes #191

* New reducers to keep track of all groups and the currently selected group id on the InstructorPage.
* Added another group to seeders so test instructor has a group in two different configurations. Enables manually testing edge cases when developing.
* Rename some tests on instructorpage to make them more descriptive.
* With these reducers, only display each group's answers if the group's id matches the selected groupID on the instructor page, or if the chosen group id is 0, which is selectable by the option "all groups".
* If the instructor switches configurations when a specific group is selected, the groupselector defaults to "all groups".