### PR TITLE
Tests/timelogs refactoring

### DIFF
--- a/backend/controllers/sprints.js
+++ b/backend/controllers/sprints.js
@@ -144,7 +144,7 @@ sprintsRouter.delete('/:id', checkLogin, async (req, res) => {
       return res.status(403).json({ error: 'User is not a member of the group.' })
     }
     const timeLogs = await db.TimeLog.findAll({ where: { sprint_id: id } })
-    if (timeLogs.length > 0) {
+    if (timeLogs.length > 0 && !req.user.admin) {
       return res.status(403).json({ error: 'Sprint has time logs, cannot delete.' })
     }
 

--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -16,11 +16,11 @@ describe('Time logs & sprints', () => {
   })
 
   beforeEach(() => {
+    cy.loginAsAdmin()
+    cy.deleteAllSprints()
+
     cy.loginAsRegisteredUser()
     cy.visit('/')
-  })
-
-  it('add 2 sprints', () => {
     cy.get('#hamburger-menu-button')
       .click()
       .then(() => {
@@ -65,7 +65,7 @@ describe('Time logs & sprints', () => {
     cy.get('#time-log-submit-button').should('be.disabled')
   })
 
-  it('add 2 time logs', () => {
+  it('adds 2 time logs and displays them successfully', () => {
     cy.get('#hamburger-menu-button')
       .click()
       .then(() => {
@@ -84,14 +84,7 @@ describe('Time logs & sprints', () => {
 
     cy.get('.notification').should('exist')
     cy.get('.notification').should('have.text', 'Time log created successfully')
-  })
 
-  it('should display 2 time logs', () => {
-    cy.get('#hamburger-menu-button')
-      .click()
-      .then(() => {
-        cy.contains('Time Log').click()
-      })
     cy.get('.timelogs-container-1').should('contain', 'test description 1')
     cy.get('.timelogs-container-1').should('contain', 'test description 2')
 
@@ -114,13 +107,13 @@ describe('Time logs & sprints', () => {
     )
   })
 
-  it('previous week should not display time logs', () => {
+  it('new sprints should not display time logs', () => {
     cy.get('#hamburger-menu-button')
       .click()
       .then(() => {
         cy.contains('Time Log').click()
       })
-    cy.get('.timelogs-container-1').should('contain', 'test description 2')
+    cy.get('#timelog-rows').children().should('have.length', 1)
     cy.get('#previous-sprint-button').click()
     cy.get('#timelog-rows').children().should('have.length', 1)
     cy.get('#timelog-rows').should('contain', 'No logs yet :(')
@@ -132,6 +125,11 @@ describe('Time logs & sprints', () => {
     .then(() => {
       cy.contains('Time Log').click()
     })
+
+    cy.get('#date').type(formatDate(new Date()))
+    cy.get('#time').type('01:00')
+    cy.get('#description').type('test description 1')
+    cy.get('#time-log-submit-button').click()
 
     cy.get(':nth-child(1) > .timelogs-description')
       .invoke('text')
@@ -151,7 +149,7 @@ describe('Time logs & sprints', () => {
         testedLogDescription
       )
     })
-    cy.get('#timelog-rows').children().should('have.length', 2)
+    cy.get('#timelog-rows').children().should('have.length', 1)
   })
 
   it('remove a time log, should not display removed time log', () => {
@@ -160,6 +158,16 @@ describe('Time logs & sprints', () => {
       .then(() => {
         cy.contains('Time Log').click()
       })
+
+    cy.get('#date').type(formatDate(new Date()))
+    cy.get('#time').type('01:00')
+    cy.get('#description').type('test description 1')
+    cy.get('#time-log-submit-button').click()
+
+    cy.get('.notification').should('exist')
+    cy.get('.notification').should('have.text', 'Time log created successfully')
+
+    cy.get('.timelogs-container-1').should('contain', 'test description 1')
 
     cy.get(':nth-child(1) > .timelogs-description')
       .invoke('text')
@@ -254,6 +262,22 @@ describe('Time logs & sprints', () => {
       cy.get('#hamburger-menu-button')
         .click()
         .then(() => {
+          cy.contains('Time Log').click()
+        })
+
+      cy.get('#date').type(formatDate(new Date()))
+      cy.get('#time').type('01:00')
+      cy.get('#description').type('test description 1')
+      cy.get('#time-log-submit-button').click()
+
+      cy.get('.notification').should('exist')
+      cy.get('.notification').should('have.text', 'Time log created successfully')
+
+      cy.get('.timelogs-container-1').should('contain', 'test description 1')
+
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
           cy.contains('Sprint Dashboard').click()
         })
 
@@ -267,38 +291,7 @@ describe('Time logs & sprints', () => {
         )
     })
 
-
     it('remove sprints, should not display sprints or time logs', () => {
-      cy.get('#hamburger-menu-button')
-      .click()
-      .then(() => {
-        cy.contains('Time Log').click()
-      })
-
-    cy.get(':nth-child(1) > .timelogs-description')
-      .invoke('text')
-      .as('removedLogDescription')
-
-    cy.get('#timelog-rows > :nth-child(1)')
-      .find('[id^="timelog-remove-button-"]')
-      .click()
-
-    cy.get('.confirmation-dialog').should(
-      'contain',
-      'Delete this time log? It cannot be restored.'
-    )
-    cy.get('.confirmation-dialog').find('#confirmation-dialog-yes-button').click()
-
-    cy.get('@removedLogDescription').then((removedLogDescription) => {
-      cy.get('#timelog-rows > :nth-child(1) > .timelogs-description').should(
-        'not.contain',
-        removedLogDescription
-      )
-    })
-
-    cy.get('#timelog-rows').children().should('have.length', 1)
-
-
       cy.get('#hamburger-menu-button')
         .click()
         .then(() => {

--- a/frontend/e2e/cypress/integration/timeLogs.spec.js
+++ b/frontend/e2e/cypress/integration/timeLogs.spec.js
@@ -11,7 +11,7 @@ describe('Time logs & sprints', () => {
       topicId: 1,
       configurationId: 1,
       instructorId: null,
-      studentIds: ['012345698'],
+      studentIds: ['012345698', '012345688'],
     })
   })
 

--- a/frontend/e2e/cypress/support/index.js
+++ b/frontend/e2e/cypress/support/index.js
@@ -717,3 +717,26 @@ Cypress.Commands.add('createGroupHack', (groupData) => {
       .then((res) => res.body)
   })
 })
+
+Cypress.Commands.add('deleteAllSprints', () => {
+  withLoggedAdminToken((token) => {
+    const authHeaders = {
+      Authorization: 'Bearer ' + token
+    }
+    cy.request({
+      url: '/api/sprints',
+      method: 'GET',
+      headers: authHeaders
+    }).then((res) => {
+      const allSprints = res.body
+      for (const sprint of allSprints) {
+        cy.request({
+          url: `/api/sprints/${sprint.id}`,
+          method: 'DELETE',
+          failOnStatusCode: false,
+          headers: authHeaders
+        })
+      }
+    })
+  })
+})


### PR DESCRIPTION
Resolves #262 

Refactors the tests regarding time logs and sprints to work independently and remove dependencies between tests. This will hopefully fix problems with the data visualization testing (#237 , #91 ) and prevent regressions.

To do this, following changes have been made:
* IMPORTANT (commit bd35e620c52cf5daaa496c2e44751a8c9f42963b), the backend validation that prevents deleting a sprint that contains time logs is bypassed if the request comes from an admin. I'd like to hear opinions on whether or not this is alright, since currently there is no way for an admin to delete sprints through the UI except if they're added as a member of the group.

* A new Cypress Command "DeleteAllSprints" has been created to reset the sprints between each test.
* The test file has been edited to login as admin, delete all tests, login as a registered user then manually add 2 sprints between each test.
* The existing tests have been refactored to account for this change.
* The admin account TEST_ADMIN has been added as a member of the test group, since sprint deletion requests from non-group members is currently not possible even for admins.