### PR TITLE
add new user group 'student - no group' and change nav bar

### DIFF
--- a/frontend/e2e/cypress/integration/menuItems.spec.js
+++ b/frontend/e2e/cypress/integration/menuItems.spec.js
@@ -64,6 +64,19 @@ describe('Menu items for different user roles', () => {
   })
 
   describe('Main menu of student', () => {
+    before(() => {
+      cy.loginAsAdmin()
+      cy.createGroup({
+        name: 'Brand New Group',
+        topicId: 1,
+        configurationId: 1,
+        instructorId: null,
+        studentIds: ['012345698'],
+      })
+    })
+    after(() => {
+      cy.deleteAllGroups()
+    })
     beforeEach(() => {
       cy.loginAsRegisteredUser()
       cy.visit('/')
@@ -113,11 +126,76 @@ describe('Menu items for different user roles', () => {
           cy.get('#hamburger-menu-popper').within(() => {
             cy.contains('Student').should('exist')
             cy.contains('Home').should('exist')
-            cy.contains('Register').should('exist')
             cy.contains('Registration Details').should('exist')
             cy.contains('Peer Review').should('exist')
             cy.contains('Time Logs').should('exist')
             cy.contains('Sprint Dashboard').should('exist')
+          })
+        })
+    })
+  })
+  describe('Main menu of student without group', () => {
+    beforeEach(() => {
+      cy.loginAsRegisteredUser()
+      cy.visit('/')
+    })
+
+
+    it('Student without group should not see admin menu items', () => {
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
+          cy.get('#hamburger-menu-popper').within(() => {
+            cy.contains('Admin').should('not.exist')
+            cy.contains('Topics').should('not.exist')
+            cy.contains('Create Topic').should('not.exist')
+            cy.contains('Reviews').should('not.exist')
+            cy.contains('Configuration').should('not.exist')
+            cy.contains('Registration Management').should('not.exist')
+            cy.contains('Current registrations').should('not.exist')
+            cy.contains('Group Management').should('not.exist')
+            cy.contains('Participants').should('not.exist')
+            cy.contains('Users').should('not.exist')
+            cy.contains('Registration Questions').should('not.exist')
+            cy.contains('Customer Review Questions').should('not.exist')
+            cy.contains('Peer Review Questions').should('not.exist')
+            cy.contains('Email Templates').should('not.exist')
+          })
+      })
+    })
+
+    it('Student without group should not see instructor menu items', () => {
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
+          cy.get('#hamburger-menu-popper').within(() => {
+            cy.contains('Instructor').should('not.exist')
+            cy.contains('Instructor Review').should('not.exist')
+            cy.contains('Reviews').should('not.exist')
+            cy.contains('Customer reviews').should('not.exist')
+          })
+        })
+    })
+
+    it('Student without group should not see student menu items', () => {
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
+          cy.get('#hamburger-menu-popper').within(() => {
+            cy.contains('Peer Review').should('not.exist')
+            cy.contains('Time Logs').should('not.exist')
+            cy.contains('Sprint Dashboard').should('not.exist')
+          })
+        })
+    })
+    it('Student without group should see student without group menu items', () => {
+      cy.get('#hamburger-menu-button')
+        .click()
+        .then(() => {
+          cy.get('#hamburger-menu-popper').within(() => {
+            cy.contains('Student - no group').should('exist')
+            cy.contains('Register').should('exist')
+            cy.contains('Registration Details').should('exist')
           })
         })
     })

--- a/frontend/src/components/common/MenuItemLists.js
+++ b/frontend/src/components/common/MenuItemLists.js
@@ -24,21 +24,12 @@ const loggedInUnregisteredItems = (history) => {
   ]
 }
 
-
-
-
-
-
 const loggedInItems = (history) => {
   return [
     {
       text: 'Home',
       handler: () => history.push('/'),
     },
-    // {
-    //   text: 'Register',
-    //   handler: () => history.push('/register'),
-    // },
     {
       text: 'Registration Details',
       handler: () => history.push('/registrationdetails'),
@@ -51,7 +42,6 @@ const loggedInItems = (history) => {
       text: 'Time Logs',
       handler: () => history.push('/timelogs'),
     },
-    // TODO: uncomment this in the Sprint Management PR.
     {
       text: 'Sprint Dashboard',
       handler: () => history.push('/sprints'),

--- a/frontend/src/components/common/MenuItemLists.js
+++ b/frontend/src/components/common/MenuItemLists.js
@@ -7,7 +7,7 @@ const regularItems = (history) => {
   ]
 }
 
-const loggedInItems = (history) => {
+const loggedInUnregisteredItems = (history) => {
   return [
     {
       text: 'Home',
@@ -17,6 +17,28 @@ const loggedInItems = (history) => {
       text: 'Register',
       handler: () => history.push('/register'),
     },
+    {
+      text: 'Registration Details',
+      handler: () => history.push('/registrationdetails'),
+    },
+  ]
+}
+
+
+
+
+
+
+const loggedInItems = (history) => {
+  return [
+    {
+      text: 'Home',
+      handler: () => history.push('/'),
+    },
+    // {
+    //   text: 'Register',
+    //   handler: () => history.push('/register'),
+    // },
     {
       text: 'Registration Details',
       handler: () => history.push('/registrationdetails'),
@@ -44,7 +66,7 @@ const instructorItems = (history) => {
       handler: () => history.push('/'),
     },
     {
-      text: 'Intructor Page',
+      text: 'Instructor Page',
       handler: () => history.push('/instructorpage'),
     },
     {
@@ -127,4 +149,4 @@ const adminItems = (history) => {
   ]
 }
 
-export { regularItems, loggedInItems, adminItems, instructorItems }
+export { regularItems, loggedInUnregisteredItems,loggedInItems, adminItems, instructorItems }

--- a/frontend/src/components/common/NavigationBar.jsx
+++ b/frontend/src/components/common/NavigationBar.jsx
@@ -13,10 +13,12 @@ import {
   loggedInItems,
   adminItems,
   instructorItems,
+  loggedInUnregisteredItems
 } from './MenuItemLists'
 import './NavigationBar.css'
 
 const NavigationBar = ({ group, user, history, logout }) => {
+
   const getAppropriateMenuItemList = () => {
     if (user === null) {
       return { items: regularItems(history) }
@@ -28,19 +30,23 @@ const NavigationBar = ({ group, user, history, logout }) => {
           { title: 'Admin', items: adminItems(history) },
           { title: 'Instructor', items: instructorItems(history) },
           { title: 'Student', items: loggedInItems(history) },
+          { title: 'Student - no group', items: loggedInUnregisteredItems(history) }
         ],
       }
     } else if (user.user.instructor) {
       return {
         items: [
           { title: 'Instructor', items: instructorItems(history) },
-          { title: 'Student', items: loggedInItems(history) }
+          { title: 'Student', items: loggedInItems(history) },
+          { title: 'Student - no group', items: loggedInUnregisteredItems(history) }
         ],
       }
-    } else {
+    } else if (group) {
       return {
         items: [{ title: 'Student', items: loggedInItems(history) }],
       }
+    } else {
+      return [{ title: 'Student - no group', items: loggedInUnregisteredItems(history) }]
     }
   }
 


### PR DESCRIPTION
resolves #269

added new user group (relevant for men options, no other functionality depend on these groups) "Student - no group". This is for students who have either not registered yet, or are registered but not assigned to group yet. This group sees in nav menu only:

- Home (with submit registration link if not already registered)
- Register (reg form or "you have already registerd" message depending on if form has been sent already)
- Registration details

Student (assigned to group) sees in menu:
- Home (redirects to registration details)
- Registration details
- Peer review
- Time Logs
- Sprint Dashboard

Instructor sees instructor items + Student items + Student-no group items
Admin see admin items + Instructor + Student + Student - no group items

Navigation menu tests updated & new tests added. 

Also Navigation menu typo fix "Intructor page" -> "Instructor page"