### PR TITLE
Feat/timelog filtering

### DIFF
--- a/backend/controllers/configurations.js
+++ b/backend/controllers/configurations.js
@@ -1,6 +1,6 @@
 const configurationsRouter = require('express').Router()
 const db = require('../models/index')
-const { checkAdmin, checkLogin } = require('../middleware')
+const { checkAdmin, checkLogin, checkInstructor } = require('../middleware')
 
 // determines which associated models are returned with configuration
 const includeArray = [
@@ -154,7 +154,7 @@ configurationsRouter.put('/:id', checkAdmin, (req, res) => {
   updateChecks(req, res)
 })
 
-configurationsRouter.get('/', checkAdmin, (req, res) => {
+configurationsRouter.get('/', checkInstructor, (req, res) => {
   db.Configuration.findAll({
     include: includeArray,
   })

--- a/backend/controllers/login.js
+++ b/backend/controllers/login.js
@@ -10,6 +10,30 @@ const handleDatabaseError = (res, error) => {
     .json({ error: 'Something is wrong... try reloading the page' })
 }
 
+const checkIfActiveInstructor = async (student_number) => {
+  try {
+    const latestConfigurationId = await db.Configuration.findOne({
+      order: [['created_at', 'DESC']],
+      attributes: ['id']
+    })
+
+    if (!latestConfigurationId) {
+      return false
+    }
+
+    const group = await db.Group.findOne({
+      where: {
+        configuration_id: latestConfigurationId.id,
+        instructor_id: student_number
+      }
+    })
+   return !!group
+  } catch (error) {
+     console.error('Error checking if active instructor:', error)
+    return false
+  }
+}
+
 loginRouter.post('/', async (req, res) => {
   if (!req.headers.hypersonstudentid)
     return res
@@ -27,7 +51,8 @@ loginRouter.post('/', async (req, res) => {
       if (foundUser) {
         //user already in database, no need to add
         const token = jwt.sign(
-          { id: foundUser.student_number, admin: foundUser.admin },
+          { id: foundUser.student_number, admin: foundUser.admin,
+            instructor: checkIfActiveInstructor(foundUser.student_number) },
           config.secret
         )
         return res.status(200).set('Cache-Control', 'no-store').json({

--- a/backend/controllers/login.js
+++ b/backend/controllers/login.js
@@ -27,9 +27,9 @@ const checkIfActiveInstructor = async (student_number) => {
         instructor_id: student_number
       }
     })
-   return !!group
+    return !!group
   } catch (error) {
-     console.error('Error checking if active instructor:', error)
+    console.error('Error checking if active instructor:', error)
     return false
   }
 }

--- a/backend/controllers/timeLogs.js
+++ b/backend/controllers/timeLogs.js
@@ -171,7 +171,7 @@ const fetchAllFromDb = async () => {
 
 timeLogsRouter.get('/', checkLogin, async (req, res) => {
   try {
-    if (req.user.admin) {
+    if (req.user.admin || req.user.instructor) {
       const timeLogs = await fetchAllFromDb()
       return res.status(200).json(timeLogs)
     }

--- a/backend/controllers/timeLogs.js
+++ b/backend/controllers/timeLogs.js
@@ -101,8 +101,80 @@ const fetchFromDb = async (studentNumber) => {
   }
 }
 
+const fetchAllFromDb = async () => {
+  try {
+    const rawLogs = await db.TimeLog.findAll({
+      attributes: [
+        ['id', 'id'],
+        ['date', 'date'],
+        ['minutes', 'minutes'],
+        ['student_number', 'studentNumber'],
+        'description',
+        [Sequelize.literal('sprint.sprint'), 'sprint'],
+        [Sequelize.literal('group_id'), 'groupId'],
+      ],
+      include: [
+        {
+          model: db.Sprint,
+          as: 'sprint',
+          attributes: [],
+        },
+        {
+          model: db.Tag,
+          as: 'tags',
+          attributes: ['title'],
+          through: { attributes: [] },
+        },
+      ],
+      raw: true,
+      order: [
+        ['date', 'DESC'],
+        ['created_at', 'DESC'],
+      ],
+    })
+
+    const timeLogMap = new Map()
+    rawLogs.forEach((log) => {
+      const {
+        id,
+        studentNumber,
+        sprint,
+        date,
+        minutes,
+        description,
+        groupId,
+        ...rest
+      } = log
+      const formattedDate = new Date(date).toISOString().slice(0, 10)
+      const timeLog = timeLogMap.get(id) || {
+        id,
+        studentNumber,
+        sprint,
+        date: formattedDate,
+        minutes,
+        description,
+        groupId,
+        tags: [],
+      }
+      const tag = rest['tags.title']
+      if (tag) {
+        timeLog.tags.push(tag)
+      }
+      timeLogMap.set(id, timeLog)
+    })
+    return Array.from(timeLogMap.values())
+  } catch (error) {
+    console.error('Error fetching time logs:', error)
+    throw new Error('Error fetching time logs.')
+  }
+}
+
 timeLogsRouter.get('/', checkLogin, async (req, res) => {
   try {
+    if (req.user.admin) {
+      const timeLogs = await fetchAllFromDb()
+      return res.status(200).json(timeLogs)
+    }
     const user_id = req.user.id
     const timeLogs = user_id ? await fetchFromDb(user_id) : []
     return res.status(200).json(timeLogs)

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -1,6 +1,6 @@
 const usersRouter = require('express').Router()
 const db = require('../models/index')
-const { checkLogin, checkInstructor, checkAdmin } = require('../middleware')
+const { checkLogin, checkInstructor } = require('../middleware')
 
 usersRouter.put('/:studentNumber', checkLogin, async (req, res) => {
   const { email } = req.body

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -1,6 +1,6 @@
 const usersRouter = require('express').Router()
 const db = require('../models/index')
-const { checkLogin, checkAdmin } = require('../middleware')
+const { checkLogin, checkInstructor, checkAdmin } = require('../middleware')
 
 usersRouter.put('/:studentNumber', checkLogin, async (req, res) => {
   const { email } = req.body
@@ -31,13 +31,39 @@ usersRouter.put('/:studentNumber', checkLogin, async (req, res) => {
   }
 })
 
-usersRouter.get('/', checkAdmin, async (req, res) => {
-  try {
-    const users = await db.User.findAll()
-    res.status(200).json(users)
-  } catch (error) {
-    console.log(error)
-    res.status(500).json({ error: 'Something is wrong... try reloading the page' })
+// If the user is an instructor, the get all of the student numbers for
+// the students in the current configuration, then gets the corresponding
+// users from the database.
+usersRouter.get('/', checkInstructor, async (req, res) => {
+  if (req.user.admin) {
+    try {
+      const users = await db.User.findAll()
+      res.status(200).json(users)
+    } catch (error) {
+      console.log(error)
+      res.status(500).json({ error: 'Something is wrong... try reloading the page' })
+    }
+  } else {
+    try {
+      const configuration = await db.Configuration.findOne({
+        order: [['createdAt', 'DESC']]
+      })
+      const groups = await db.Group.findAll({
+        where: { configurationId: configuration.id },
+        include: [{ model: db.User, as: 'students' }],
+      })
+      const studentNumbersInGroups = groups.map(
+        group => group.students.map(
+          student => student.student_number)).flat()
+
+      const users = await db.User.findAll({
+        where: { student_number: studentNumbersInGroups }
+      })
+      res.status(200).json(users)
+    } catch (error) {
+      console.log(error)
+      res.status(500).json({ error: 'Something is wrong... try reloading the page' })
+    }
   }
 })
 

--- a/backend/middleware.js
+++ b/backend/middleware.js
@@ -69,6 +69,21 @@ const checkLogin = (req, res, next) => {
 }
 
 /** @type {RequestHandler} */
+const checkInstructor = (req, res, next) => {
+  const { error, status, token } = authenticateToken(req)
+  if (!token) {
+    return res.status(status).json({ error })
+  }
+
+  if (!token.instructor && !token.admin) {
+    return res.status(401).json({ error: 'not instructor' })
+  }
+
+  req.user = token
+  next()
+}
+
+/** @type {RequestHandler} */
 const checkAdmin = (req, res, next) => {
   const { error, status, token } = authenticateToken(req)
   if (!token) {
@@ -106,6 +121,7 @@ const logger = (request, response, next) => {
 
 module.exports = {
   checkLogin,
+  checkInstructor,
   checkAdmin,
   logger,
   fakeshibbo,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,7 @@ import Registrations from './components/Registrations'
 import InstructorReviews from './components/InstructorReviews'
 import ViewUsersPage from './components/ViewUsersPage/ViewUsersPage'
 import TimeLogsPage from './components/TimeLogsPage/TimeLogsPage'
+import InstructorTimeLogsPage from './components/TimeLogsPage/InstructorTimeLogsPage'
 import SprintsDashboard from './components/SprintsPage/SprintsDashboard'
 import TagsDashboard from './components/TagManagementPage/TagsDashboard'
 
@@ -246,7 +247,10 @@ const App = (props) => {
               path="/adminstration/customer-reviews"
               render={renderWithLoadingCheck(<ViewCustomerReviewsPage />)}
             />
-
+            <InstructorRoute
+              path="/instructor-timelogs"
+              render = {renderWithLoadingCheck(<InstructorTimeLogsPage />)}
+            />
             <LoginRoute
               exact
               path="/registrationdetails"

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -53,13 +53,16 @@ const InstructorTimeLogsPage = () => {
 
   return (
     <div>
-      <TimeLogsSelectForm
-        students={allStudents}
-        handleStudentChange={setSelectedStudent}
-      />
-      <div>{selectedStudent}</div>
-      {selectedGroup && <div>{selectedGroup.groupName}</div>}
-     </div>
+      <div>
+        <TimeLogsSelectForm
+          students={allStudents}
+          selectedStudent={selectedStudent}
+          handleStudentChange={setSelectedStudent}
+        />
+        <div>{selectedStudent}</div>
+        {selectedGroup && <div>{selectedGroup.groupName}</div>}
+      </div>
+   </div>
   )
 }
 

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -49,7 +49,6 @@ const InstructorTimeLogsPage = () => {
     }
 
     fetchGroup()
-    console.log(selectedGroup)
   }, [selectedStudent])
 
   return (

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -10,7 +10,7 @@ import groupManagementService from '../../services/groupManagement'
 import timeLogsService from '../../services/timeLogs'
 
 const InstructorTimeLogsPage = () => {
-  const [selectedStudent, setSelectedStudent] = useState(null)
+  const [selectedStudentNumber, setSelectedStudentNumber] = useState(null)
   const [allStudents, setAllStudents] = useState([])
   const [allLogs, setAllLogs] = useState(null)
   const [selectedGroup, setSelectedGroup] = useState(null)
@@ -76,7 +76,7 @@ const InstructorTimeLogsPage = () => {
 
   const isLogs = (logs) => logs && logs.length > 0
   const logsByStudent =
-    isLogs(allLogs) && allLogs.filter((log) => log.studentNumber === selectedStudent)
+    isLogs(allLogs) && allLogs.filter((log) => log.studentNumber === selectedStudentNumber)
 
   if (isLoading) return <LoadingSpinner />
   return (
@@ -87,10 +87,9 @@ const InstructorTimeLogsPage = () => {
           selectedGroup={selectedGroup}
           handleGroupChange={setSelectedGroup}
           students={allStudents}
-          selectedStudent={selectedStudent}
-          handleStudentChange={setSelectedStudent}
+          selectedStudentNumber={selectedStudentNumber}
+          handleStudentNumberChange={setSelectedStudentNumber}
         />
-        <div>{selectedStudent}</div>
         {selectedGroup && <div>{selectedGroup.name}</div>}
       </div>
       <div id='timelog-rows'>

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -11,6 +11,7 @@ import timeLogsService from '../../services/timeLogs'
 const InstructorTimeLogsPage = () => {
   const [selectedStudent, setSelectedStudent] = useState(null)
   const [allStudents, setAllStudents] = useState([])
+  const [allLogs, setAllLogs] = useState(null)
   const [selectedGroup, setSelectedGroup] = useState(null)
 
   useEffect(() => {
@@ -29,7 +30,26 @@ const InstructorTimeLogsPage = () => {
         }
       }
 
-      fetchAllStudents()
+      const fetchAllLogs = async () => {
+        try {
+          const allLogs = await timeLogsService.getTimeLogs()
+          setAllLogs(allLogs)
+        } catch (error) {
+          console.error(
+            'Error fetching logs:',
+            error.message,
+            ' / ',
+            error.response.data.error
+          )
+          notificationActions.setError(error.response.data.error)
+        }
+      }
+
+      const fetchData = async () => {
+        await fetchAllStudents()
+        await fetchAllLogs()
+      }
+      fetchData()
     }, [])
 
   useEffect(() => {
@@ -51,6 +71,10 @@ const InstructorTimeLogsPage = () => {
     fetchGroup()
   }, [selectedStudent])
 
+  const isLogs = (logs) => logs && logs.length > 0
+  const logsByStudent =
+    isLogs(allLogs) && allLogs.filter((log) => log.studentNumber === selectedStudent)
+
   return (
     <div>
       <div>
@@ -61,6 +85,18 @@ const InstructorTimeLogsPage = () => {
         />
         <div>{selectedStudent}</div>
         {selectedGroup && <div>{selectedGroup.groupName}</div>}
+      </div>
+      <div id='timelog-rows'>
+        {isLogs(logsByStudent) &&
+          logsByStudent.map((log) => (
+            <TimeLogRow
+              key={log.id}
+              log={log}
+            />
+          ))}
+        {!isLogs(logsByStudent) && (
+          <p>No logs yet :&#40;</p>
+        )}
       </div>
    </div>
   )

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -1,0 +1,11 @@
+import { withRouter } from 'react-router-dom'
+
+const InstructorTimeLogsPage = () => {
+  return (
+      <div>Hello Instructor!</div>
+  )
+}
+
+export default withRouter(
+  (InstructorTimeLogsPage)
+)

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react'
+import { withRouter } from 'react-router-dom'
 
 import { TimeLogsSelectForm } from './TimeLogsSelectForm'
-
-import { withRouter } from 'react-router-dom'
+import { TimeLogRow } from './TimeLogRow'
 
 import userService from '../../services/user'
 import groupManagementService from '../../services/groupManagement'
+import timeLogsService from '../../services/timeLogs'
 
 const InstructorTimeLogsPage = () => {
   const [selectedStudent, setSelectedStudent] = useState(null)

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -6,10 +6,13 @@ import { TimeLogRow } from './TimeLogRow'
 import LoadingSpinner from '../common/LoadingSpinner'
 
 import userService from '../../services/user'
+import configurationService from '../../services/configuration'
 import groupManagementService from '../../services/groupManagement'
 import timeLogsService from '../../services/timeLogs'
 
 const InstructorTimeLogsPage = () => {
+  const [allConfigurations, setAllConfigurations] = useState([])
+  const [selectedConfiguration, setSelectedConfiguration] = useState(null)
   const [allGroups, setAllGroups] = useState([])
   const [selectedGroup, setSelectedGroup] = useState(null)
   const [allStudents, setAllStudents] = useState([])
@@ -19,6 +22,21 @@ const InstructorTimeLogsPage = () => {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
+    const fetchAllConfigurations = async () => {
+      try {
+        const allConfigurations = await configurationService.getAll()
+        setAllConfigurations(allConfigurations.configurations)
+      } catch (error) {
+        console.error(
+          'Error fetching groups:',
+          error.message,
+          ' / ',
+          error.response.data.error
+        )
+        notificationActions.setError(error.response.data.error)
+      }
+    }
+
       const fetchAllGroups = async () => {
         try {
           const allGroups = await groupManagementService.get()
@@ -66,6 +84,7 @@ const InstructorTimeLogsPage = () => {
 
       const fetchData = async () => {
         setIsLoading(true)
+        await fetchAllConfigurations()
         await fetchAllGroups()
         await fetchAllStudents()
         await fetchAllLogs()
@@ -83,6 +102,9 @@ const InstructorTimeLogsPage = () => {
     <div>
       <div>
         <TimeLogsSelectForm
+          configurations={allConfigurations}
+          selectedConfiguration={selectedConfiguration}
+          handleConfigurationChange={setSelectedConfiguration}
           groups={allGroups}
           selectedGroup={selectedGroup}
           handleGroupChange={setSelectedGroup}
@@ -101,7 +123,7 @@ const InstructorTimeLogsPage = () => {
             />
           ))}
         {!isLogs(logsByStudent) && (
-          <p>No logs yet :&#40;</p>
+          <p>No logs by the selected user.</p>
         )}
       </div>
    </div>

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -1,8 +1,65 @@
+import React, { useEffect, useState } from 'react'
+
+import { TimeLogsSelectForm } from './TimeLogsSelectForm'
+
 import { withRouter } from 'react-router-dom'
 
+import userService from '../../services/user'
+import groupManagementService from '../../services/groupManagement'
+
 const InstructorTimeLogsPage = () => {
+  const [selectedStudent, setSelectedStudent] = useState(null)
+  const [allStudents, setAllStudents] = useState([])
+  const [selectedGroup, setSelectedGroup] = useState(null)
+
+  useEffect(() => {
+      const fetchAllStudents = async () => {
+        try {
+          const allStudents = await userService.get()
+          setAllStudents(allStudents)
+        } catch (error) {
+          console.error(
+            'Error fetching students:',
+            error.message,
+            ' / ',
+            error.response.data.error
+          )
+          notificationActions.setError(error.response.data.error)
+        }
+      }
+
+      fetchAllStudents()
+    }, [])
+
+  useEffect(() => {
+    const fetchGroup = async () => {
+      try {
+        const group = await groupManagementService.getByStudent(selectedStudent)
+        setSelectedGroup(group)
+      } catch (error) {
+        console.error(
+          'Error fetching group:',
+          error.message,
+          ' / ',
+          error.response.data.error
+        )
+        notificationActions.setError(error.response.data.error)
+      }
+    }
+
+    fetchGroup()
+    console.log(selectedGroup)
+  }, [selectedStudent])
+
   return (
-      <div>Hello Instructor!</div>
+    <div>
+      <TimeLogsSelectForm
+        students={allStudents}
+        handleStudentChange={setSelectedStudent}
+      />
+      <div>{selectedStudent}</div>
+      {selectedGroup && <div>{selectedGroup.groupName}</div>}
+     </div>
   )
 }
 

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -10,11 +10,11 @@ import groupManagementService from '../../services/groupManagement'
 import timeLogsService from '../../services/timeLogs'
 
 const InstructorTimeLogsPage = () => {
-  const [selectedStudentNumber, setSelectedStudentNumber] = useState(null)
-  const [allStudents, setAllStudents] = useState([])
-  const [allLogs, setAllLogs] = useState(null)
-  const [selectedGroup, setSelectedGroup] = useState(null)
   const [allGroups, setAllGroups] = useState([])
+  const [selectedGroup, setSelectedGroup] = useState(null)
+  const [allStudents, setAllStudents] = useState([])
+  const [selectedStudentNumber, setSelectedStudentNumber] = useState(null)
+  const [allLogs, setAllLogs] = useState(null)
 
   const [isLoading, setIsLoading] = useState(true)
 

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -8,7 +8,7 @@ export const TimeLogsSelectForm = ({
   groups, selectedGroup, handleGroupChange,
   students, selectedStudentNumber, handleStudentNumberChange }) => {
 
-  const ConfigurationSelectWrapper = ({ label, children }) => (
+  const SelectorWrapper = ({ label, children }) => (
     <div style={{ padding: 20 }}>
       <Typography variant="caption">{label}</Typography>
       {children}
@@ -48,13 +48,6 @@ export const TimeLogsSelectForm = ({
     return group.configurationId === configuration.id
   }
 
-  const GroupSelectWrapper = ({ label, children }) => (
-    <div style={{ padding: 20 }}>
-      <Typography variant="caption">{label}</Typography>
-      {children}
-    </div>
-  )
-
   const GroupSelect = ({
     groups,
     selectedGroup,
@@ -85,13 +78,6 @@ export const TimeLogsSelectForm = ({
   const StudentIsInGroup = ( student, group ) => {
     return group.studentIds.includes(student.student_number)
   }
-  
-  const StudentSelectWrapper = ({ label, children }) => (
-    <div style={{ padding: 20 }}>
-      <Typography variant="caption">{label}</Typography>
-      {children}
-    </div>
-  )
 
   const StudentSelect = ({
     selectedGroup,
@@ -125,7 +111,7 @@ export const TimeLogsSelectForm = ({
   return (
     <div className="timelog-select-container">
       <div className="selector-container">
-        <ConfigurationSelectWrapper label="Select configuration">
+        <SelectorWrapper label="Select configuration">
           <ConfigurationSelect
             configurations={configurations}
             selectedConfiguration={selectedConfiguration}
@@ -133,26 +119,26 @@ export const TimeLogsSelectForm = ({
             handleGroupChange={handleGroupChange}
             handleStudentNumberChange={handleStudentNumberChange}
           />
-        </ConfigurationSelectWrapper>
+        </SelectorWrapper>
         {selectedConfiguration &&
-          <GroupSelectWrapper label="Select group">
+          <SelectorWrapper label="Select group">
             <GroupSelect
               selectedGroup={selectedGroup}
               handleGroupChange={handleGroupChange}
               groups={groups}
               handleStudentNumberChange={handleStudentNumberChange}
             />
-          </GroupSelectWrapper>
+          </SelectorWrapper>
         }
         {selectedGroup &&
-          <StudentSelectWrapper label="Select student">
+          <SelectorWrapper label="Select student">
             <StudentSelect
               selectedGroup={selectedGroup}
               selectedStudentNumber={selectedStudentNumber}
               handleStudentNumberChange={handleStudentNumberChange}
               students={students}
             />
-          </StudentSelectWrapper>
+          </SelectorWrapper>
         }
       </div>
     </div>

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -1,0 +1,53 @@
+import './TimeLogsPage.css'
+import MenuItem from '@material-ui/core/MenuItem'
+import Typography from '@material-ui/core/Typography'
+import Select from '@material-ui/core/Select'
+
+export const TimeLogsSelectForm = ({ students, handleStudentChange }) => {
+  const StudentSelectWrapper = ({ label, children }) => (
+    <div style={{ padding: 20 }}>
+      <Typography variant="caption">{label}</Typography>
+      {children}
+    </div>
+  )
+  
+  const StudentSelect = ({
+    students,
+    currentStudent,
+    handleStudentChange
+  }) => {
+    return (
+      <Select
+        data-cy="student-selector"
+        value={currentStudent}
+        onChange={(e) => {
+          handleStudentChange(e.target.value)
+        }}
+      >
+        {students.map((student) => (
+          <MenuItem
+            key={student.student_number}
+            className="student-menu-item"
+            value={student.student_number}
+          >
+            {student.first_names}
+          </MenuItem>
+        ))}
+      </Select>
+    )
+  }
+
+  return (
+    <div className="timelog-select-container">
+      <div className="selector-container">
+        <StudentSelectWrapper label="Select student">
+          <StudentSelect
+            currentStudent={currentStudent}
+            handleStudentChange={handleStudentChange}
+            students={students}
+          />
+        </StudentSelectWrapper>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -5,7 +5,7 @@ import Select from '@material-ui/core/Select'
 
 export const TimeLogsSelectForm = ({
   groups, selectedGroup, handleGroupChange,
-  students, selectedStudent, handleStudentChange }) => {
+  students, selectedStudentNumber, handleStudentNumberChange }) => {
   const GroupSelectWrapper = ({ label, children }) => (
     <div style={{ padding: 20 }}>
       <Typography variant="caption">{label}</Typography>
@@ -24,7 +24,7 @@ export const TimeLogsSelectForm = ({
         value={selectedGroup}
         onChange={(e) => {
           handleGroupChange(e.target.value)
-          handleStudentChange(null)
+          handleStudentNumberChange(null)
         }}
       >
         {groups.map((group) => (
@@ -53,15 +53,15 @@ export const TimeLogsSelectForm = ({
   const StudentSelect = ({
     selectedGroup,
     students,
-    selectedStudent,
-    handleStudentChange
+    selectedStudentNumber,
+    handleStudentNumberChange
   }) => {
     return (
       <Select
         data-cy="student-selector"
-        value={selectedStudent}
+        value={selectedStudentNumber}
         onChange={(e) => {
-          handleStudentChange(e.target.value)
+          handleStudentNumberChange(e.target.value)
         }}
         disabled={!selectedGroup}
       >
@@ -87,15 +87,15 @@ export const TimeLogsSelectForm = ({
             selectedGroup={selectedGroup}
             handleGroupChange={handleGroupChange}
             groups={groups}
-            handleStudentChange={handleStudentChange}
+            handleStudentNumberChange={handleStudentNumberChange}
           />
         </GroupSelectWrapper>
         {selectedGroup &&
           <StudentSelectWrapper label="Select student">
             <StudentSelect
               selectedGroup={selectedGroup}
-              selectedStudent={selectedStudent}
-              handleStudentChange={handleStudentChange}
+              selectedStudentNumber={selectedStudentNumber}
+              handleStudentNumberChange={handleStudentNumberChange}
               students={students}
             />
           </StudentSelectWrapper>

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -3,15 +3,55 @@ import MenuItem from '@material-ui/core/MenuItem'
 import Typography from '@material-ui/core/Typography'
 import Select from '@material-ui/core/Select'
 
-export const TimeLogsSelectForm = ({ students, selectedStudent, handleStudentChange }) => {
+export const TimeLogsSelectForm = ({
+  groups, selectedGroup, handleGroupChange,
+  students, selectedStudent, handleStudentChange }) => {
+  const GroupSelectWrapper = ({ label, children }) => (
+    <div style={{ padding: 20 }}>
+      <Typography variant="caption">{label}</Typography>
+      {children}
+    </div>
+  )
+
+  const GroupSelect = ({
+    groups,
+    selectedGroup,
+    handleGroupChange
+  }) => {
+    return (
+      <Select
+        data-cy="group-selector"
+        value={selectedGroup}
+        onChange={(e) => {
+          handleGroupChange(e.target.value)
+          handleStudentChange(null)
+        }}
+      >
+        {groups.map((group) => (
+          <MenuItem
+            key={group.id}
+            className="group-menu-item"
+            value={group}
+          >
+            {group.name}
+          </MenuItem>
+        ))}
+      </Select>
+  )}
+
+  const StudentIsInGroup = ( student, group ) => {
+    return group.studentIds.includes(student.student_number)
+  }
+  
   const StudentSelectWrapper = ({ label, children }) => (
     <div style={{ padding: 20 }}>
       <Typography variant="caption">{label}</Typography>
       {children}
     </div>
   )
-  
+
   const StudentSelect = ({
+    selectedGroup,
     students,
     selectedStudent,
     handleStudentChange
@@ -23,8 +63,10 @@ export const TimeLogsSelectForm = ({ students, selectedStudent, handleStudentCha
         onChange={(e) => {
           handleStudentChange(e.target.value)
         }}
+        disabled={!selectedGroup}
       >
-        {students.map((student) => (
+        {students.filter(student => StudentIsInGroup(student, selectedGroup))
+          .map((student) => (
           <MenuItem
             key={student.student_number}
             className="student-menu-item"
@@ -40,13 +82,24 @@ export const TimeLogsSelectForm = ({ students, selectedStudent, handleStudentCha
   return (
     <div className="timelog-select-container">
       <div className="selector-container">
-        <StudentSelectWrapper label="Select student">
-          <StudentSelect
-            selectedStudent={selectedStudent}
+        <GroupSelectWrapper label="Select group">
+          <GroupSelect
+            selectedGroup={selectedGroup}
+            handleGroupChange={handleGroupChange}
+            groups={groups}
             handleStudentChange={handleStudentChange}
-            students={students}
           />
-        </StudentSelectWrapper>
+        </GroupSelectWrapper>
+        {selectedGroup &&
+          <StudentSelectWrapper label="Select student">
+            <StudentSelect
+              selectedGroup={selectedGroup}
+              selectedStudent={selectedStudent}
+              handleStudentChange={handleStudentChange}
+              students={students}
+            />
+          </StudentSelectWrapper>
+        }
       </div>
     </div>
   )

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -3,7 +3,7 @@ import MenuItem from '@material-ui/core/MenuItem'
 import Typography from '@material-ui/core/Typography'
 import Select from '@material-ui/core/Select'
 
-export const TimeLogsSelectForm = ({ students, handleStudentChange }) => {
+export const TimeLogsSelectForm = ({ students, selectedStudent, handleStudentChange }) => {
   const StudentSelectWrapper = ({ label, children }) => (
     <div style={{ padding: 20 }}>
       <Typography variant="caption">{label}</Typography>
@@ -13,13 +13,13 @@ export const TimeLogsSelectForm = ({ students, handleStudentChange }) => {
   
   const StudentSelect = ({
     students,
-    currentStudent,
+    selectedStudent,
     handleStudentChange
   }) => {
     return (
       <Select
         data-cy="student-selector"
-        value={currentStudent}
+        value={selectedStudent}
         onChange={(e) => {
           handleStudentChange(e.target.value)
         }}
@@ -42,7 +42,7 @@ export const TimeLogsSelectForm = ({ students, handleStudentChange }) => {
       <div className="selector-container">
         <StudentSelectWrapper label="Select student">
           <StudentSelect
-            currentStudent={currentStudent}
+            selectedStudent={selectedStudent}
             handleStudentChange={handleStudentChange}
             students={students}
           />

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -4,8 +4,50 @@ import Typography from '@material-ui/core/Typography'
 import Select from '@material-ui/core/Select'
 
 export const TimeLogsSelectForm = ({
+  configurations, selectedConfiguration, handleConfigurationChange,
   groups, selectedGroup, handleGroupChange,
   students, selectedStudentNumber, handleStudentNumberChange }) => {
+
+  const ConfigurationSelectWrapper = ({ label, children }) => (
+    <div style={{ padding: 20 }}>
+      <Typography variant="caption">{label}</Typography>
+      {children}
+    </div>
+  )
+
+  const ConfigurationSelect = ({
+    configurations,
+    selectedConfiguration,
+    handleConfigurationChange,
+    handleGroupChange,
+    handleStudentNumberChange
+  }) => {
+    return (
+      <Select
+        data-cy="configuration-selector"
+        value={selectedConfiguration}
+        onChange={(e) => {
+          handleConfigurationChange(e.target.value)
+          handleGroupChange(null)
+          handleStudentNumberChange(null)
+        }}
+      >
+        {configurations.map((configuration) => (
+          <MenuItem
+            key={configuration.id}
+            className="configuration-menu-item"
+            value={configuration}
+          >
+            {configuration.name}
+          </MenuItem>
+        ))}
+      </Select>
+  )}
+
+  const GroupIsInConfiguration = ( group, configuration ) => {
+    return group.configurationId === configuration.id
+  }
+
   const GroupSelectWrapper = ({ label, children }) => (
     <div style={{ padding: 20 }}>
       <Typography variant="caption">{label}</Typography>
@@ -27,7 +69,8 @@ export const TimeLogsSelectForm = ({
           handleStudentNumberChange(null)
         }}
       >
-        {groups.map((group) => (
+        {groups.filter(group => GroupIsInConfiguration(group, selectedConfiguration))
+          .map((group) => (
           <MenuItem
             key={group.id}
             className="group-menu-item"
@@ -82,14 +125,25 @@ export const TimeLogsSelectForm = ({
   return (
     <div className="timelog-select-container">
       <div className="selector-container">
-        <GroupSelectWrapper label="Select group">
-          <GroupSelect
-            selectedGroup={selectedGroup}
+        <ConfigurationSelectWrapper label="Select configuration">
+          <ConfigurationSelect
+            configurations={configurations}
+            selectedConfiguration={selectedConfiguration}
+            handleConfigurationChange={handleConfigurationChange}
             handleGroupChange={handleGroupChange}
-            groups={groups}
             handleStudentNumberChange={handleStudentNumberChange}
           />
-        </GroupSelectWrapper>
+        </ConfigurationSelectWrapper>
+        {selectedConfiguration &&
+          <GroupSelectWrapper label="Select group">
+            <GroupSelect
+              selectedGroup={selectedGroup}
+              handleGroupChange={handleGroupChange}
+              groups={groups}
+              handleStudentNumberChange={handleStudentNumberChange}
+            />
+          </GroupSelectWrapper>
+        }
         {selectedGroup &&
           <StudentSelectWrapper label="Select student">
             <StudentSelect

--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -30,7 +30,7 @@ export const TimeLogsSelectForm = ({ students, selectedStudent, handleStudentCha
             className="student-menu-item"
             value={student.student_number}
           >
-            {student.first_names}
+            {student.first_names} {student.last_name}
           </MenuItem>
         ))}
       </Select>

--- a/frontend/src/components/common/MenuItemLists.js
+++ b/frontend/src/components/common/MenuItemLists.js
@@ -55,6 +55,10 @@ const instructorItems = (history) => {
       text: 'Customer reviews',
       handler: () => history.push('/adminstration/customer-reviews'),
     },
+    {
+      text: 'Time Logs (Instructor)',
+      handler: () => history.push('/instructor-timelogs'),
+    }
   ]
 }
 


### PR DESCRIPTION
Related to #246 

This PR creates a page where administrators and instructors of the latest configuration can view students' time logs. The logs can be filtered by group, and instructors can only see logs written by students who belong to groups of the latest configuration.

PROBLEMS:
* The bar charts have not been implemented, as this branch has already grown large.
* There is no proper seed data to manually check if the instructor is only limited to groups/students of the latest configuration. This has been manually tested by manually reassigning the test group "ohtuilmo-ryhmä" to the last created configuration, "Kevät 2024"
* Instructors will lose access to the time logs when a newer configuration is created, which may be a problem when grading.
* No automated tests for the specific page have been made, due to the urgency of the feature.
* The logs are currently not separated by sprint.
* The delete button for logs remains, but does not do anything despite clicking the confirm button on the confirmation prompt.

CHANGES IN A NUTSHELL:
* The login functionality has been edited to check if the logged user is assigned as an instructor to any group of the latest configuration. This information is stored into the session token, which is used to confirm access to some backend requests.
* The page fetches all configurations when first loaded, then all groups, then all users and finally fetches all time logs. These are stored in state hooks.
    * Admin users fetch complete information, where as instructors are limited to group and user data from the latest configuration.
* The page has three dropdown-selectors, which only become clickable when their predecessors are selected. These selectors filter the previously fetched information and display the logs accordingly.