### PR TITLE
hotfix: remove log delete btn until log display fixed

### DIFF
--- a/frontend/src/components/TimeLogsPage/TimeLogRow.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogRow.jsx
@@ -1,14 +1,10 @@
-import React, { useState } from 'react'
 import { minutesToFormattedHoursAndMinutes } from '../../utils/functions'
-import { DeleteOutlineRounded } from '@material-ui/icons'
-import { IconButton, Chip } from '@material-ui/core'
-import ConfirmationDialog from '../common/ConfirmationDialog'
+import { Chip } from '@material-ui/core'
 
 import './TimeLogsPage.css'
 
-export const TimeLogRow = ({ log, handleDelete }) => {
+export const TimeLogRow = ({ log }) => {
   const { hours, minutes } = minutesToFormattedHoursAndMinutes(log.minutes)
-  const [confirmOpen, setConfirmOpen] = useState(false)
 
   const dateObj = new Date(log.date)
   const formattedDate = dateObj.toLocaleDateString('fi-FI', {
@@ -29,23 +25,6 @@ export const TimeLogRow = ({ log, handleDelete }) => {
         <div className="timelogs-description">
           <p>{log.description}</p>
         </div>
-        <IconButton
-          id={`timelog-remove-button-${log.id}`}
-          className="timelogs-remove-button"
-          style={{ padding: '0 12px' }}
-          disableRipple
-          onClick={() => setConfirmOpen(true)}
-        >
-          <DeleteOutlineRounded />
-        </IconButton>
-        <ConfirmationDialog
-          title="Delete Time Log?"
-          open={confirmOpen}
-          setOpen={setConfirmOpen}
-          onConfirm={handleDelete}
-        >
-          Delete this time log? It cannot be restored.
-        </ConfirmationDialog>
       </div>
       <div className="timelogs-tags-row">
         {log.tags.map((tag) => (


### PR DESCRIPTION
This PR prevents users from deleting time logs, until we have fixed the bug where all time logs are displayed to all users.