### PR TITLE
fix: all timelogs being visible to all students

### DIFF
--- a/backend/controllers/timeLogs.js
+++ b/backend/controllers/timeLogs.js
@@ -171,7 +171,7 @@ const fetchAllFromDb = async () => {
 
 timeLogsRouter.get('/', checkLogin, async (req, res) => {
   try {
-    if (req.user.admin || req.user.instructor) {
+    if (req.user.admin) {
       const timeLogs = await fetchAllFromDb()
       return res.status(200).json(timeLogs)
     }


### PR DESCRIPTION
Something seems to be wrong with the instructor checking, so this commit prevents anyone but admin from fetching all time logs.

This PR will prevent users (and instructors) from seeing timelogs by other users.