### PR TITLE
feature: instructor time logs automatically select correct configuration and group

### DIFF
--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -119,6 +119,7 @@ const InstructorTimeLogsPage = (props) => {
           newestGroupByInstructor.configurationId === configuration.id
       )
       setSelectedConfiguration(configurationByInstructor)
+      setSelectedGroup(newestGroupByInstructor)
     }
   }, [allConfigurations, allGroups])
 

--- a/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
+++ b/frontend/src/components/TimeLogsPage/InstructorTimeLogsPage.jsx
@@ -22,7 +22,8 @@ const InstructorTimeLogsPage = (props) => {
   const {
     selectedSprintNumber,
     setSelectedSprintNumber,
-    setGroupSprintSummary
+    setGroupSprintSummary,
+    user,
   } = props
 
   const [allConfigurations, setAllConfigurations] = useState([])
@@ -107,6 +108,19 @@ const InstructorTimeLogsPage = (props) => {
     }
     fetchData()
   }, [])
+
+  useEffect(() => {
+    if (allConfigurations.length > 0 && allGroups.length > 0) {
+      const newestGroupByInstructor = allGroups.findLast(
+        group => group.instructor === user.user.id
+      )
+      const configurationByInstructor = allConfigurations.find(
+        configuration =>
+          newestGroupByInstructor.configurationId === configuration.id
+      )
+      setSelectedConfiguration(configurationByInstructor)
+    }
+  }, [allConfigurations, allGroups])
 
   useEffect(() => {
     const fetchGroupSprintSummary = async (group_id) => {
@@ -220,6 +234,7 @@ const InstructorTimeLogsPage = (props) => {
 const mapStateToProps = (state) => ({
   state: state,
   selectedSprintNumber: state.timeLogs.selectedSprintNumber,
+  user: state.login.user,
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
This PR introduces a feature that automatically selects the latest configuration and group for instructors when viewing time logs for their group of students.

Made in collaboration between @amandahamynen and @VSirvio