### PR TITLE
fix: pudotusvalikkojen ylimpiä vaihtoehtoja ei ohjaajan time log -sivulla pysty aina valitsemaan

### DIFF
--- a/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
+++ b/frontend/src/components/TimeLogsPage/TimeLogsSelectForm.jsx
@@ -32,6 +32,7 @@ export const TimeLogsSelectForm = ({
           handleGroupChange(null)
           handleStudentNumberChange(null)
         }}
+        MenuProps={{ style: { zIndex: 1600 } }}
       >
         {configurations.map((configuration) => (
           <MenuItem
@@ -62,6 +63,7 @@ export const TimeLogsSelectForm = ({
           handleGroupChange(e.target.value)
           handleStudentNumberChange(null)
         }}
+        MenuProps={{ style: { zIndex: 1600 } }}
       >
         {groups.filter(group => GroupIsInConfiguration(group, selectedConfiguration))
           .map((group) => (
@@ -94,6 +96,7 @@ export const TimeLogsSelectForm = ({
           handleStudentNumberChange(e.target.value)
         }}
         disabled={!selectedGroup}
+        MenuProps={{ style: { zIndex: 1600 } }}
       >
         {students.filter(student => StudentIsInGroup(student, selectedGroup))
           .map((student) => (


### PR DESCRIPTION
This PR fixes the bug found in issue #312 by increasing the z-index for dropdown menus. The menus now appear over the header bar.

Made in collaboration between @amandahamynen  and @VSirvio. 

Closes #312 