### PR TITLE
feature: opiskelijan projektiin käyttämien työtuntien automaattinen esitäyttö vertaispalautteessa

### DIFF
--- a/backend/controllers/timeLogs.js
+++ b/backend/controllers/timeLogs.js
@@ -272,4 +272,25 @@ timeLogsRouter.delete('/:id', checkLogin, async (req, res) => {
   }
 })
 
+timeLogsRouter.get('/projectHoursUsed', checkLogin, async (req, res) => {
+  const studentNumber = req.user.id
+  try {
+    const hours = await db.TimeLog.findAll({
+      where: {
+        student_number: studentNumber,
+      },
+    })
+
+    let totalHours = 0
+    hours.forEach((hour) => {
+      totalHours += hour.minutes / 60
+    })
+
+    return res.status(200).json(totalHours)
+  } catch (error) {
+    console.error('Error fetching project hours:', error)
+    return res.status(500).json({ error: 'Error fetching project hours' })
+  }
+})
+
 module.exports = timeLogsRouter

--- a/frontend/src/components/PeerReviewPage.jsx
+++ b/frontend/src/components/PeerReviewPage.jsx
@@ -53,7 +53,7 @@ class PeerReview extends React.Component {
         type: 'number',
         questionHeader: question.header,
         id: questionId,
-        answer: projectHours,
+        answer: Math.round(projectHours),
       }
     }
 

--- a/frontend/src/components/PeerReviewPage.jsx
+++ b/frontend/src/components/PeerReviewPage.jsx
@@ -62,8 +62,17 @@ class PeerReview extends React.Component {
       return peerAnswers
     }
 
+    const projectHours = await peerReviewService.getProjectHoursUsed()
+
     const initializeNumberAnswer = (question, questionId) => {
-      return {
+      if (question.header === 'Kuinka monta tuntia käytit projektin parissa?') {
+        return {
+          type: 'number',
+          questionHeader: question.header,
+          id: questionId,
+          answer: projectHours,
+        }
+      } else return {
         type: 'number',
         questionHeader: question.header,
         id: questionId,

--- a/frontend/src/components/PeerReviewPage.jsx
+++ b/frontend/src/components/PeerReviewPage.jsx
@@ -46,6 +46,17 @@ class PeerReview extends React.Component {
   }
 
   async fetchPeerReviewQuestions(peers, questionObject) {
+    const projectHours = await peerReviewService.getProjectHoursUsed()
+
+    const initializeProjectHours = (question, questionId) => {
+      return {
+        type: 'number',
+        questionHeader: question.header,
+        id: questionId,
+        answer: projectHours,
+      }
+    }
+
     const initializeRadioAnswer = (question, questionId) => {
       let peerAnswers = {
         type: 'radio',
@@ -62,17 +73,8 @@ class PeerReview extends React.Component {
       return peerAnswers
     }
 
-    const projectHours = await peerReviewService.getProjectHoursUsed()
-
     const initializeNumberAnswer = (question, questionId) => {
-      if (question.header === 'Kuinka monta tuntia käytit projektin parissa?') {
-        return {
-          type: 'number',
-          questionHeader: question.header,
-          id: questionId,
-          answer: projectHours,
-        }
-      } else return {
+      return {
         type: 'number',
         questionHeader: question.header,
         id: questionId,
@@ -108,7 +110,9 @@ class PeerReview extends React.Component {
 
     const tempAnswerSheet = questionObject.questions.map(
       (question, questionID) => {
-        if (question.type === 'radio') {
+        if (question.header === 'Kuinka monta tuntia käytit ohjelmistotuotantoprojektiin yhteensä?') {
+          return initializeProjectHours(question, questionID)
+        } else if (question.type === 'radio') {
           return initializeRadioAnswer(question, questionID)
         } else if (question.type === 'peerReview') {
           return initializePeerReview(question, questionID)

--- a/frontend/src/services/peerReview.js
+++ b/frontend/src/services/peerReview.js
@@ -36,4 +36,15 @@ const getReviewQuestions = async (configurationId, reviewRound) => {
   return response.data
 }
 
-export default { get, create, getReviewQuestions, getAnswersByInstructor }
+const getProjectHoursUsed = async () => {
+  const response = await axios.get(
+    `${BACKEND_API_BASE}/timelogs/projectHoursUsed`,
+    {
+      headers: { Authorization: 'Bearer ' + getUserToken() }
+    }
+  )
+
+  return response.data
+}
+
+export default { get, create, getReviewQuestions, getAnswersByInstructor, getProjectHoursUsed }


### PR DESCRIPTION
Opiskelijoiden vertaisarviointikysymykseen "Kuinka monta tuntia käytit ohjelmistotuotantoprojektiin yhteensä?" haetaan nyt tieto opiskelijan kirjaamista työtunneista automaattisesti.

<img width="1056" height="188" alt="Näyttökuva 2025-08-19 kello 20 59 05" src="https://github.com/user-attachments/assets/31dbb2e4-c28e-42eb-9a93-d300aef55fab" />

Tunnit lasketaan backendissä ja esitäytetään lomakkeeseen automaattisesti kokonaisluvun tarkkuudella. Opiskelija voi halutessaan muokata esitäytettyä arvoa. Kenttää ei ole lukittu disabled-attribuutilla, koska sen voisi kiertää selaimen kehitystyökaluilla. Tästä syystä mahdollisuus manuaaliseen muokkaukseen on jätetty käyttöön.

Toteutin tuntikysymyksen käsittelyn hieman poikkeavasti tarkistamalla kysymyksen header-kentän arvon suoraan, koska kysymykset haetaan suoraan tietokannasta. Jos kyseessä on juuri tämä kysymys, palautetaan initializeProjectHours-funktiolla esitäytetty vastaus. Muut kysymystyypit käsitellään normaalisti niiden type-kentän perusteella (radio, peerReview, jne). Tällä tavalla pystyin välttämään muutokset tietokantaan/kysymysten rakenteeseen.

Backend vaati hieman enemmän työtä, koska otin huomioon myös tapaukset, joissa opiskelija on aiemmin kuulunut toiseen ryhmään. Työtuntien laskennassa huomioidaan vain uusimman ryhmän sprintit.

Closes #322 