### PR TITLE
changed cypress.config.js to use require instead of import

### DIFF
--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -1,6 +1,6 @@
-import { defineConfig } from 'cypress'
+const { defineConfig } = require('cypress')
 
-export default defineConfig({
+module.exports = defineConfig({
   fixturesFolder: 'e2e/cypress/fixtures',
   screenshotsFolder: 'e2e/cypress/screenshots',
   videosFolder: 'e2e/cypress/videos',


### PR DESCRIPTION
When using the older `require` syntax for importing, `e2e` tests can now be reliably run locally inside docker compose. This implementation of the config is also shown in Cypress docs. Although it is mentioned that `cypress.config.mjs` would allow you to use ES6 imports but it doesn't seem to work.