### PR TITLE
feature: toggle on/off -painike tageille

### DIFF
--- a/frontend/src/components/TagPage/StaffTagPage.jsx
+++ b/frontend/src/components/TagPage/StaffTagPage.jsx
@@ -245,7 +245,7 @@ const StaffTagPage = (props) => {
           selectedStudentNumber={selectedStudentNumber}
           handleStudentNumberChange={handleStudentChange}
         />
-        <Typography variant="h4">Tags</Typography>
+        <Typography variant="h5">Tags</Typography>
         <CheckboxMultiSelect
           allItems={availableTags}
           selectedItems={selectedTags}

--- a/frontend/src/components/TagPage/StaffTagPage.jsx
+++ b/frontend/src/components/TagPage/StaffTagPage.jsx
@@ -258,11 +258,13 @@ const StaffTagPage = (props) => {
         ) : (
           <>
             <Typography variant="h5">
-              {!selectedGroupId
-                ? 'Select a group'
-                : selectedStudentNumber === 0
-                  ? `Tag usage for ${selectedGroup?.name ?? ''}`
-                  : `Tag usage for ${selectedStudent?.first_names ?? ''} ${selectedStudent?.last_name ?? ''}`
+              {!selectedConfigurationId
+                ? 'Select configuration'
+                : !selectedGroupId
+                  ? 'Select a group'
+                  : selectedStudentNumber === 0
+                    ? `Tag usage for ${selectedGroup?.name ?? ''}`
+                    : `Tag usage for ${selectedStudent?.first_names ?? ''} ${selectedStudent?.last_name ?? ''}`
               }
             </Typography>
             <TagUsageBarChart

--- a/frontend/src/components/TagPage/StudentTagPage.jsx
+++ b/frontend/src/components/TagPage/StudentTagPage.jsx
@@ -92,7 +92,7 @@ const StudentTagPage = (props) => {
   return (
     <div className="tagpage-container">
       <div className="tagpage-selection-container">
-        <Typography variant="h4">Tags</Typography>
+        <Typography variant="h5">Tags</Typography>
         <CheckboxMultiSelect
           allItems={availableTags}
           selectedItems={selectedTags}

--- a/frontend/src/components/TagPage/TagPage.css
+++ b/frontend/src/components/TagPage/TagPage.css
@@ -14,7 +14,7 @@
   flex-direction: column;
   max-width: 600px;
   margin-bottom: 26px;
-  gap: 38px;
+  gap: 20px;
 }
 
 .tagpage-charts-container {

--- a/frontend/src/components/common/CheckboxMultiSelect.jsx
+++ b/frontend/src/components/common/CheckboxMultiSelect.jsx
@@ -5,27 +5,45 @@ import {
   FormGroup,
 } from '@material-ui/core'
 
-const CheckboxMultiSelect = ({allItems, selectedItems, setSelectedItems, isHorizontal}) => (
-  <FormGroup row={isHorizontal}>
-    {allItems.map(item =>
+const CheckboxMultiSelect = ({allItems, selectedItems, setSelectedItems, isHorizontal}) => {
+  const allSelected = selectedItems.length === allItems.length
+  const handleToggleAll = (event, checked) => {
+    setSelectedItems(checked ? allItems : [])
+  }
+
+  return (
+    <>
       <FormControlLabel
-        key={item}
         control={
           <Checkbox
-            checked={selectedItems.includes(item)}
-            onChange={(event, checked) =>
-              setSelectedItems(checked
-                ? [item, ...selectedItems]
-                : selectedItems.filter(x => x !== item)
-              )
-            }
+            checked={allSelected}
+            onChange={handleToggleAll}
           />
         }
-        label={item}
+        label="Toggle all"
       />
-    )}
-  </FormGroup>
-)
+      <FormGroup row={isHorizontal}>
+        {allItems.map(item =>
+          <FormControlLabel
+            key={item}
+            control={
+              <Checkbox
+                checked={selectedItems.includes(item)}
+                onChange={(event, checked) =>
+                  setSelectedItems(checked
+                    ? [item, ...selectedItems]
+                    : selectedItems.filter(x => x !== item)
+                  )
+                }
+              />
+            }
+            label={item}
+          />
+        )}
+      </FormGroup>
+    </>
+  )
+}
 
 CheckboxMultiSelect.defaultProps = {
   isHorizontal: false,


### PR DESCRIPTION
Lisätty tag-sivuille toggle on/off -painike, jolla kaikki tagit voi valita tai poistaa valinnasta yhdellä klikkauksella.

Lisäksi tehty pieniä ulkoasuun liittyviä parannuksia:

- Muutettu 'Tags'-otsikon typografia (h4 → h5)
- Lisätty teksti "Select configuration" StaffTagPage-näkymään tilanteessa, jossa konfiguraatiota ei ole valittu
- Pienennetty tagpage-selection-container -elementin väliä

closes #352 